### PR TITLE
Added Issue Template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,53 @@
+#### Issue Type
+- [ ] Story
+- [ ] Scenario
+- [ ] Task
+
+#### Story 
+(As a <user type> I want <goal> so that <benefit>.)
+
+#### Detailed Description
+
+#### Definition of Done (To add to the Backlog)
+- [ ] User Story Complete
+- [ ] Linked EPIC
+- [ ] Label (Story, Scenario, Task)
+
+#### Definition of Done (Add to a Sprint)
+- [ ] Service Design Artifacts Attached
+- [ ] Acceptance Criteria Complete
+- [ ] BDD Pseudo-Code Started
+- [ ] Estimated
+- [ ] Prioritized
+
+---
+#### Scenario
+#### Detailed Description
+#### BDD Pseudo-Code
+#### Acceptance Criteria Checklist (Testable)
+#### Definition of Done (To add to the Backlog)
+- [ ] User Story Complete
+- [ ] Linked EPIC
+- [ ] Label (Story, Scenario, Task)
+
+#### Definition of Done (Add to a Sprint)
+- [ ] Service Design Artifacts Attached
+- [ ] Acceptance Criteria Complete
+- [ ] BDD Pseudo-Code Started
+- [ ] Estimated
+- [ ] Prioritized
+
+---
+#### Task
+#### Detailed Description
+#### Definition of Done (To add to the Backlog)
+- [ ] User Story Complete
+- [ ] Linked EPIC
+- [ ] Label (Story, Scenario, Task)
+
+#### Definition of Done (Add to a Sprint)
+- [ ] Service Design Artifacts Attached
+- [ ] Acceptance Criteria Complete
+- [ ] BDD Pseudo-Code Started
+- [ ] Estimated
+- [ ] Prioritized


### PR DESCRIPTION
Added issue template to manage zenhub board.  This template will be used by all issues in github./zenhub.  This is just a a place to start and we can customize as the team sees fit.

Acceptance Criteria:
-Issue template is defined for epics, stories, scenarios, tasks including the definition of done  for each issue type.