### PR TITLE
Various recipe steps/severity changes and button show/hide on state.

### DIFF
--- a/client/src/components/application/Examine/NameMatches.vue
+++ b/client/src/components/application/Examine/NameMatches.vue
@@ -25,8 +25,8 @@
          @click="clickRecipeCard('Trademarks')">Trademarks &reg;</a>
       <div class="arrow-right"></div>
 
-      <div id="History1" class="icon icon-pass">
-        <i id="History2" class="fa fa-check"></i></div>
+      <div id="History1">
+        <i id="History2"></i></div>
       <a class="nav-link" data-toggle="pill" href="#"
          @click="clickRecipeCard('History')">History</a>
       <div class="arrow-right"></div>
@@ -50,6 +50,7 @@ export default {
     this.setConflicts();
     this.setConditions();
     this.setTrademarks();
+    this.setHistory();
   },
   computed: {
     currentRecipeCard: {
@@ -69,14 +70,27 @@ export default {
     trademarkInfo() {
       return this.$store.getters.trademarksJSON;
     },
+    historyInfo() {
+      return this.$store.getters.historiesJSON;
+    },
   },
   methods: {
     clickRecipeCard(recipeCard) {
       this.currentRecipeCard = recipeCard
     },
     setConflicts() {
-      // TODO - implement business rules for pass/concern/fail for trademarks
-      this.setConcern('Conflict');
+      /*
+      If there are any conflicts, set to FAIL; otherwise PASS.
+       */
+      if (this.conflictsInfo == null || this.conflictsInfo == undefined) {
+        this.setPass('Conflict');
+      }
+      else if (this.conflictsInfo.names.length == 0) {
+        this.setPass('Conflict');
+      }
+      else {
+        this.setFail('Conflict');
+      }
     },
     setConditions() {
       // if no restricted words -> call setPass
@@ -122,8 +136,32 @@ export default {
       }
     },
     setTrademarks() {
-      // TODO - implement business rules for pass/concern/fail for trademarks
-      this.setConcern('Trademarks');
+      /*
+      If there are any trademarks, set to FAIL; otherwise PASS.
+       */
+      if (this.trademarkInfo == null || this.trademarkInfo == undefined) {
+        this.setPass('Trademarks');
+      }
+      else if (this.trademarkInfo.names.length == 0) {
+        this.setPass('Trademarks');
+      }
+      else {
+        this.setFail('Trademarks');
+      }
+    },
+    setHistory() {
+      /*
+      If there is any history, set to CONCERN; otherwise PASS.
+       */
+      if (this.historyInfo == null || this.historyInfo == undefined) {
+        this.setPass('History');
+      }
+      else if (this.historyInfo.names.length == 0) {
+        this.setPass('History');
+      }
+      else {
+        this.setConcern('History');
+      }
     },
     setFail(val){
       console.log('fail + ' + val);
@@ -151,7 +189,7 @@ export default {
     }
   },
   watch: {
-    conflictInfo: function (val) {
+    conflictsInfo: function (val) {
       // set severity flag on recipe menu
       this.setConflicts();
     },
@@ -162,6 +200,10 @@ export default {
     trademarkInfo: function (val) {
       // set severity flag on recipe menu
       this.setTrademarks();
+    },
+    historyInfo: function (val) {
+      // set severity flag on recipe menu
+      this.setHistory();
     },
   },
 }

--- a/client/src/components/application/NameExamination.vue
+++ b/client/src/components/application/NameExamination.vue
@@ -17,7 +17,7 @@
        </div>
 
        <decision v-if="is_making_decision" />
-       <div class="row" v-else>
+       <div class="row" v-else-if="!is_complete">
          <compmatches />
          <div class="col"><matchissues /></div>
        </div>
@@ -51,7 +51,10 @@
       },
       is_making_decision() {
         return this.$store.getters.is_making_decision;
-      }
+      },
+      is_complete() {
+        return this.$store.getters.is_complete;
+      },
     },
     components: {
       requestinfoheaderview,

--- a/client/src/components/application/sections/StdHeader.vue
+++ b/client/src/components/application/sections/StdHeader.vue
@@ -45,7 +45,7 @@
                  placeholder="NR Number" aria-label="Search" v-model="nrNum">
           <button class="btn btn-outline-success my-2 my-sm-0" type="submit">Load</button>
         </form>
-        <p class="navbar-text">&nbsp;{{userid}}</p>
+        <p class="navbar-text">&nbsp;{{userId }}</p>
       </div>
     </nav>
   </div>
@@ -61,8 +61,8 @@
       }
     },
     computed: {
-      userid() {
-        return this.$store.getters.userid
+      userId() {
+        return this.$store.getters.userId
       },
       auth() {
         return this.$store.getters.isAuthenticated


### PR DESCRIPTION
- fixed setting of User ID from login data.
- run recipes with every new NR that gets pulled from individual load; NOT when the NR is complete
- run recipes with every new NR from next off queue ("oldest")
- add "Examine" button to transition from HOLD to INPROGRESS
- remove manual search from complete NRs
- do green/red severity for conflicts and trademarks (green=no results, else red)
- do green/orange for history (green=no results, else orange)