### PR TITLE
Added NWPTA view and edit functionality.

### DIFF
--- a/client/src/components/application/Examine/RequestInfoHeader.vue
+++ b/client/src/components/application/Examine/RequestInfoHeader.vue
@@ -42,10 +42,10 @@
             <!-- spacer -->
           </div>
           <div class="col">
-            <nwpta v-if="nwpta_required" jurisdiction="AB" />
+            <nwpta v-if="nwpta_required" jurisdiction="AB" ref="nwpta_ab"  />
           </div>
           <div class="col">
-            <nwpta v-if="nwpta_required" jurisdiction="SK" />
+            <nwpta v-if="nwpta_required" jurisdiction="SK" ref="nwpta_sk"  />
           </div>
         </div>
 
@@ -496,9 +496,6 @@ export default {
         // if previous NR not required, clear the data
         if (!this.prev_nr_required) this.$store.commit('previousNr', null);
 
-        // if NWPTA not required, clear the data
-        // TODO
-
 
         // build Additional Info
         this.buildAdditionalInfo();
@@ -548,7 +545,10 @@ export default {
             // NWPTA placeholder
             // if there is no NWPTA data for this placeholder, do not use this bit of the template
             if (template.indexOf('<nwpta>') > -1) {
-              // TODO
+              // KBM 2018-08-22 - Do nothing - I don't think we need to add to Additional Info for
+              // NWPTA because it will have been added during initial entry into NRO, and we do not
+              // change nwpta type (assumed, numbered) to trigger adding/changing anything in
+              // Additional Info.
             }
 
             /*
@@ -594,9 +594,12 @@ export default {
         // trigger vuelidate validation in this component and child component
         this.$v.$touch();
         this.$refs.clientinfoview.$v.$touch();
+        this.$refs.nwpta_ab.$v.$touch();
+        this.$refs.nwpta_sk.$v.$touch();
 
         // return opposite of 'invalid' flags, since we want to know if this IS valid
-        return !this.$v.$invalid && !this.$refs.clientinfoview.$v.$invalid;
+        return !this.$v.$invalid && !this.$refs.clientinfoview.$v.$invalid &&
+          !this.$refs.nwpta_ab.$v.$invalid && !this.$refs.nwpta_sk.$v.$invalid;
       },
     },
     watch: {

--- a/client/src/components/application/Examine/nwpta/nwpta.vue
+++ b/client/src/components/application/Examine/nwpta/nwpta.vue
@@ -1,21 +1,59 @@
 /* eslint-disable */
 <template>
-  <span v-if="is_editing && is_complete">
+  <span v-if="is_editing && has_nwpta && !is_numbered_assumed">
 
-    <span class="nwpta" v-if="nwpta.partnerJurisdictionTypeCd !== null">
-      <h3 class="add-top-padding">{{ nwpta.partnerJurisdictionTypeCd }}</h3>
-      <input type="text" v-model="nwpta.partnerNameNumber" class="form-control" />
-      <input type="text" v-model="nwpta.partnerName" class="form-control" />
+    <span class="nwpta" :id="id">
+      <h3 class="add-top-padding">
+        {{ jurisdiction }} <span v-if="is_named_assumed">(Assumed)</span>
+      </h3>
+
+      <!-- number -->
+      <span>
+        <input type="text" v-model="nwpta.partnerNameNumber" class="form-control"
+               placeholder="Number" maxlength="20" />
+      </span>
+
+      <!-- name - only for "Named Assumed" type -->
+      <span v-if="is_named_assumed">
+        <input type="text" v-model="nwpta.partnerName" class="form-control" placeholder="Name"
+               maxlength="255" />
+      </span>
+
+      <!-- date -->
+      <span :class="{'form-group-error': $v.nwpta.partnerNameDate.$error}">
+        <input type="text" v-model="nwpta.partnerNameDate" class="form-control"
+               placeholder="Expiry Date" :onchange="$v.nwpta.partnerNameDate.$touch()" />
+        <div class="date-helper-text">DD-MM-YYYY</div>
+        <div class="error" v-if="!$v.nwpta.partnerNameDate.isValidFormat">
+          Date must be in format DD-MM-YYYY.</div>
+        <div class="error" v-else-if="!$v.nwpta.partnerNameDate.isActualDate">
+          This is not an actual date. Date must be in format DD-MM-YYYY.</div>
+      </span>
     </span>
 
   </span>
-  <span v-else>
+  <span v-else-if="(!is_editing || is_numbered_assumed) && has_nwpta">
 
-    <span class="nwpta" v-if="nwpta.partnerJurisdictionTypeCd !== null">
-      <h3 class="add-top-padding">{{ nwpta.partnerJurisdictionTypeCd }}</h3>
+    <span class="nwpta" :id="id">
+      <h3 class="add-top-padding">
+        {{ jurisdiction }}
+        <span v-if="is_named_assumed">(Assumed)</span>
+        <span v-if="nwpta_requested">REQUESTED</span>
+      </h3>
+      <div v-if="is_numbered_assumed">Numbered Assumed</div>
+
+      <!-- number -->
       {{ nwpta.partnerNameNumber }}
-      <br/>
-      {{ nwpta.partnerName }}
+
+      <!-- name - only for "Named Assumed" type -->
+      <span v-if="is_named_assumed">
+        <br/>
+        {{ nwpta.partnerName }}
+      </span>
+
+      <!-- date -->
+      <br />
+      {{ nwpta.partnerNameDate }}
     </span>
 
   </span>
@@ -33,35 +71,90 @@
     props: {
       jurisdiction: null,
     },
+    validations: {
+
+      nwpta: {
+        partnerNameDate: {
+          isValidFormat(value) {
+            // if empty, it's valid - not required
+            if (value == '' || value == null) return true;
+
+            // check for format DD-MM-YYYY
+            if (value.match(/\d\d-\d\d-\d\d\d\d/gi) == null) return false;
+
+            // check that second numbers (month) aren't > 12, in which case user has probably
+            // switched day and month
+            if (value.substr(3, 2) > 12) {
+              return false;
+            }
+
+            return true;
+          },
+          isActualDate(value) {
+
+            // if empty, it's valid - not required
+            if (value == '' || value == null) return true;
+
+            // try to convert string to Date object - if it's not an actual date (like Feb 31)
+            // this will fail either by setting a date that's not actually the date (ie: it tries
+            // to fix the data you gave it), or by returning "Invalid Date".
+            var fakedate = new Date(value.substr(6,4), (value.substr(3,2)-1), value.substr(0,2));
+            if (fakedate == "Invalid Date") return false;
+            if (fakedate.getUTCDate() != value.substr(0,2)*1) return false;
+
+            return true;
+
+          },
+        }
+      },
+    },
     computed: {
       is_editing() {
         return  this.$store.getters.is_editing;
-      },
-      is_complete() {
-        return this.$store.getters.is_complete;
       },
       nwpta() {
         if (this.jurisdiction == 'AB') return this.$store.getters.nwpta_ab;
         else if (this.jurisdiction == 'SK') return this.$store.getters.nwpta_sk;
         else return null;
       },
-    },
-    mounted(){
-    },
-    watch: {
-    },
-    methods: {
-      toggleDetails() {
+      has_nwpta() {
+        if (this.nwpta == null) return false;
+        if (this.nwpta.partnerJurisdictionTypeCd == null) return false;
+        return true;
       },
-      edit() {
-        this.$store.state.is_editing = true;
+      nwpta_requested() {
+        // Is this a "do it for me" request? Indicated by a nwpta record but no name or number data.
+        // EXCEPT NAS (numbered assumed) - these also have no data but are not requested
+        if (this.nwpta.partnerNameTypeCd != null && this.nwpta.partnerNameTypeCd != 'NAS' &&
+            (this.nwpta.partnerName == null || this.nwpta.partnerName == '') &&
+            (this.nwpta.partnerNameNumber == null || this.nwpta.partnerNameNumber == '')
+        ) {
+          return true;
+        }
+        else return false;
       },
-      save() {
-        this.$store.state.is_editing = false;
-      }
-    }
+      is_named_assumed() {
+        // if the type is AS, this is an assumed name type
+        if (this.nwpta.partnerNameTypeCd == 'AS') return true;
+        else return false;
+      },
+      is_numbered_assumed() {
+        // if the type is NAS, this is a NUMBERED assumed type
+        if (this.nwpta.partnerNameTypeCd == 'NAS') return true;
+        else return false;
+      },
+      id () {
+        // id for identifying nwpta segments in Selenium tests
+        return "nwpta-" + this.jurisdiction;
+      },
+    },
   }
 </script>
 
 <style scoped>
+  .date-helper-text {
+    font-style: italic;
+    color: grey;
+    text-align: center;
+  }
 </style>

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -467,6 +467,16 @@ mutations: {
 
       // cycle through nwpta entries
       for (let record of dbcompanyInfo.nwpta) {
+
+        // convert date from long form to DD-MM-YYYY
+        if (record.partnerNameDate != null && record.partnerNameDate != '') {
+          var nwpta_date = new Date(record.partnerNameDate);
+          record.partnerNameDate =
+            padWithZeroes(nwpta_date.getUTCDate(), 2) + "-" +
+            padWithZeroes((nwpta_date.getUTCMonth() + 1), 2) + "-" +
+            nwpta_date.getFullYear();
+        }
+
         if (record.partnerJurisdictionTypeCd == 'AB') state.additionalCompInfo.nwpta_ab = record;
         if (record.partnerJurisdictionTypeCd == 'SK') state.additionalCompInfo.nwpta_sk = record;
       }

--- a/client/static/js/utils.js
+++ b/client/static/js/utils.js
@@ -101,3 +101,8 @@ function getTextFromValueMultiple(haystack, needle) {
   // return array of matches, not just single value
   return haystack.filter(findArrValue(needle));
 }
+
+function padWithZeroes(num, size) {
+    var s = "000000000" + num;
+    return s.substr(s.length-size);
+}


### PR DESCRIPTION
*Issue #:* #653 

*Description of changes:*
This handles displaying the various types of NWPTA/NUANS, display and editing. 

Assumptions:
- examiner cannot change which type of record this is, ie: from number (CO or LP), assumed name (AS), and assumed number (NAS).
- examiner cannot create a new nwpta record where one does not exist, ie: can't add a Saskatchewan record if it wasn't either requested (as a do-it-for-me request) or filled in by customer.
- we do not want to remove the data in the case of switching from a request type that uses/displays nwpta and one that does not. Ie: we don't clear the data if we switch away from a request type that does not need it. We just ignore it.
- all Additional Info canned text will be filled in by NRO when submitted by customer, and Namex will not adjust that automatically - ie: we have no need to add to it because we're not creating nwpta records that don't already exist. And we won't delete it from Additional Info, the examiner can do that manually if it is no longer relevant.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
