### PR TITLE
Bug fix - current choice always 1 when coming back to HOLD NRs, even if

### DIFF
--- a/client/src/components/application/Examine/RequestInfoHeader.vue
+++ b/client/src/components/application/Examine/RequestInfoHeader.vue
@@ -615,6 +615,7 @@ export default {
       nrNumber: function (val) {
         console.log('RequestInfoHeader.nrNumber watcher fired:' )
         this.$store.dispatch('getpostgrescompInfo',this.nrNumber)
+        this.$store.dispatch('runRecipe');
       },
       requestType: function(val) {
         /*

--- a/client/src/components/application/Examine/RequestInfoHeader.vue
+++ b/client/src/components/application/Examine/RequestInfoHeader.vue
@@ -615,13 +615,6 @@ export default {
       nrNumber: function (val) {
         console.log('RequestInfoHeader.nrNumber watcher fired:' )
         this.$store.dispatch('getpostgrescompInfo',this.nrNumber)
-        if( this.$store.getters.currentChoice == null || this.$store.getters.currentChoice == 1 ){
-          console.log('RequestInfoHeader.watch runRecipe:' + val)
-          this.$store.dispatch('runRecipe')
-        } else {
-          console.log('RequestInfoHeader.watch set currentChoice to 1')
-          this.$store.commit('currentChoice',1)
-        }
       },
       requestType: function(val) {
         /*

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -336,7 +336,10 @@ mutations: {
       state.compInfo.compNames.compName3.conflict3 = null
       state.compInfo.compNames.compName3.decision_text = null
 
-
+      // clear current name choice, to be reset by new data below
+      state.currentNameObj = null;
+      state.currentName = null;
+      state.currentChoice = null;
 
 
       for (let record of dbcompanyInfo.names) {
@@ -1034,8 +1037,6 @@ mutations: {
 
       console.log('Getting NR data')
       dispatch('getpostgrescompInfo',nrNum)
-
-      commit('currentChoice',1)
 
       console.log('Running Recipe')
       dispatch('runRecipe')


### PR DESCRIPTION
*Issue #:* NO TICKET, JUST FOUND BUG.

*Description of changes:*
Bug fix - current choice always 1 when coming back to HOLD NRs, even if it should be 2 or 3. Reset current choice upon new NR data so always correct. 



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
