### PR TITLE
Fixed bug - history exact match variable not being reset between NRs …

### DIFF
--- a/client/src/components/application/NameExamination.vue
+++ b/client/src/components/application/NameExamination.vue
@@ -87,6 +87,10 @@
         return this.$store.getters.historiesJSON;
       },
       exactHistoryMatches() {
+
+        // initialize to reset any previous value
+        this.exactMatch = null;
+
         try {
           var currentName = this.$store.getters.currentName.toUpperCase();
           // check for exact matches in history for alert re. previous submissions


### PR DESCRIPTION
*Issue #:* #766 

*Description of changes:*
Fixed bug - history exact match variable not being reset between NRs so watcher not triggered.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
