### PR TITLE
Moved all state header code into StateHeader.vue instead of split bet…

### DIFF
--- a/client/src/components/application/NameExamination.vue
+++ b/client/src/components/application/NameExamination.vue
@@ -5,9 +5,7 @@
 
       <div class="namePage" >
 
-        <div v-bind:style="{ 'margin-left': '-15px', 'margin-right': '-15px', 'margin-top': '-22px','margin-bottom': '10px', 'background-color': bgColor }">
-          <stateheaderview />
-        </div>
+        <stateheaderview />
 
         <div class="RequestInfoHeader">
           <requestinfoheaderview />
@@ -63,7 +61,6 @@
           visible: true,
           exactMatch: null,
           model: false,
-          bgColor: ''
         }
     },
     computed: {
@@ -86,7 +83,6 @@
         return this.$store.getters.userId;
       },
       currentState() {
-        this.setBGC();
         return this.$store.getters.currentState;
       },
       historiesJSON() {
@@ -124,38 +120,6 @@
         }
       },
     },
-    methods: {
-        setBGC() {
-          switch(this.$store.getters.currentState) {
-            case 'HOLD':
-              this.bgColor = 'yellow';
-              break;
-            case 'INPROGRESS':
-              this.bgColor = 'lime';
-              break;
-            case 'DRAFT':
-              this.bgColor = 'violet';
-              break;
-            case 'EXPIRED':
-              this.bgColor = 'orange';
-              break;
-            case 'CANCELLED':
-              this.bgColor = 'red';
-              break;
-            case 'APPROVED':
-              this.bgColor = 'dodgerblue';
-              break;
-            case 'CONDITIONAL':
-              this.bgColor = 'dodgerblue';
-              break;
-            case 'REJECTED':
-              this.bgColor = 'red';
-              break;
-            default:
-              this.bgColor = 'grey';
-          }
-        }
-    },
     components: {
       stateheaderview,
       requestinfoheaderview,
@@ -186,10 +150,7 @@
     margin-top: 10px;
 
   }
-  .stateheaderview {
-    margin-top: -21px;
-    padding-bottom: 2px;
-  }
+
   .examiner-warning {
     margin-left: -15px;
     margin-right: -15px;

--- a/client/src/components/application/sections/StateHeader.vue
+++ b/client/src/components/application/sections/StateHeader.vue
@@ -1,23 +1,68 @@
 <!--eslint-disable-->
 <template>
-  <span>
+  <div class="stateheaderview" v-bind:style="{ 'background-color': bgColor }">
     <p class="state-text">{{currentState}}</p>
-  </span>
+  </div>
 </template>
 
 <script>
 /* eslint-disable */
   export default {
     name: "stateHeader",
+    data: function () {
+      return {
+        bgColor: '',
+      }
+    },
     computed: {
       currentState() {
-        return this.$store.getters.currentState
-      }
+        this.setBGC();
+        return this.$store.getters.currentState;
+      },
+    },
+    methods: {
+      setBGC() {
+        switch(this.$store.getters.currentState) {
+          case 'HOLD':
+            this.bgColor = 'yellow';
+            break;
+          case 'INPROGRESS':
+            this.bgColor = 'lime';
+            break;
+          case 'DRAFT':
+            this.bgColor = 'violet';
+            break;
+          case 'EXPIRED':
+            this.bgColor = 'orange';
+            break;
+          case 'CANCELLED':
+            this.bgColor = 'red';
+            break;
+          case 'APPROVED':
+            this.bgColor = 'dodgerblue';
+            break;
+          case 'CONDITIONAL':
+            this.bgColor = 'dodgerblue';
+            break;
+          case 'REJECTED':
+            this.bgColor = 'red';
+            break;
+          default:
+            this.bgColor = 'grey';
+        }
+      },
     }
   }
 </script>
 
 <style scoped>
+  .stateheaderview {
+    margin-left: -15px;
+    margin-right: -15px;
+    margin-top: -22px;
+    margin-bottom: 10px;
+  }
+
   .state-text {
     text-align: center;
     font-size: 1.5em;


### PR DESCRIPTION
…ween StateHeader and NameExamination.

*Issue #:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
