### PR TITLE
bug fix - moved check for name choice from inside for loop to outside.

### DIFF
--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -414,11 +414,12 @@ mutations: {
             console.log('got to a name record with null choice - moving on');
             break;
         }
-        //if no currentName selected choose 1st
-        if(state.currentName == null){
-          console.log('No currentName set => use 1st choice: ', state.currentChoice)
-          this.dispatch('setCurrentName',dbcompanyInfo.names[0])
-        }
+      }
+
+      //if no currentName selected choose 1st
+      if(state.currentName == null){
+        console.log('No currentName set => use 1st choice: ', state.currentChoice)
+        this.dispatch('setCurrentName',dbcompanyInfo.names[0])
       }
 
       console.log('Still loading')


### PR DESCRIPTION
*Issue #:* #881 

*Description of changes:*
Bug - name choice 1 being set as current name choice even when it should be 2 or 3 (under certain conditions). Problem was that it was inside for-loop cycling over name data from GET. Moved to outside loop so condition only checked AFTER all names had been processed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
