### PR TITLE
Updated keycloak.js path for new domain.

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -9,7 +9,7 @@
   <meta name="msapplication-TileImage" content="static/icons/ms-icon-144x144.png"/>
   <meta name="theme-color" content="#ffffff"/>
 
-  <title>BC Registry: Name Examination</title>
+  <title>BC Registry: Name Examination </title>
 
   <!-- BOOTSTRAP CORE CSS -->
   <link rel="stylesheet" href="static/css/bootstrap.min.css">
@@ -48,7 +48,7 @@
 <!-- Read JSon config files utility-->
 <script src="/static/js/utils.js"></script>
 <!-- Keycloak authorization class -->
-<script src="https://dev-sso.pathfinder.gov.bc.ca/auth/js/keycloak.js"></script>
+<script src="https://sso-dev.pathfinder.gov.bc.ca/auth/js/keycloak.js"></script>
 <!--<script src="/static/js/readConfig.js"></script>-->
 </body>
 </html>


### PR DESCRIPTION
*Issue #:* n/a

*Description of changes:*
Updated path to keycloak.js - old path (dev-sso) stopped being available, so we switched to new domain (sso-dev).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
