### PR TITLE
Removed sync of closed NR from NRO to Namex.

### DIFF
--- a/client/src/components/application/Examine/RequestInfoHeader.vue
+++ b/client/src/components/application/Examine/RequestInfoHeader.vue
@@ -567,9 +567,14 @@ export default {
         if (!this.is_my_current_nr && !this.is_closed) {
           this.$store.dispatch('updateNRState', 'INPROGRESS');
         }
+
+        // KBM - REMOVED per ticket #970
+        /*
         if (this.is_closed) {
           this.$store.dispatch('syncNR',this.nrNumber);
         }
+        */
+
         this.$store.state.is_editing = true;
       },
       save() {


### PR DESCRIPTION
*Issue #:* #970 

*Description of changes:*
Removed sync of closed NR from NRO to Namex. In discussions, we decided it was unnecessary and the master record after closing is Namex and no info (that is held in Namex) is updated by NRO.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
