### PR TITLE
Update font for corporate section

### DIFF
--- a/client/src/components/application/Examine/Recipe/conflicts/ConflictInfo.vue
+++ b/client/src/components/application/Examine/Recipe/conflicts/ConflictInfo.vue
@@ -67,10 +67,9 @@ import corpMatch from '@/components/application/Examine/Recipe/conflicts/conflic
     padding: 10px;
   }
 
-  h3, h2 {
+h3, h2 {
     font-size: 15px;
   }
-
   p {
     font-size: 14px;
   }

--- a/client/src/components/application/Examine/Recipe/conflicts/conflictInfoType/corpMatch.vue
+++ b/client/src/components/application/Examine/Recipe/conflicts/conflictInfoType/corpMatch.vue
@@ -158,6 +158,12 @@
   .corpType {
     color: #494969;
   }
+  h3, h2 {
+    font-size: 15px;
+  }
+  p {
+    font-size: 14px;
+  }
 </style>
 
 

--- a/client/src/components/application/Examine/Recipe/conflicts/conflictInfoType/namesMatch.vue
+++ b/client/src/components/application/Examine/Recipe/conflicts/conflictInfoType/namesMatch.vue
@@ -157,6 +157,12 @@
 </script>
 
 <style scoped>
+    h3, h2 {
+    font-size: 15px;
+  }
+  p {
+    font-size: 14px;
+  }
 </style>
 
 

--- a/client/static/css/main.css
+++ b/client/static/css/main.css
@@ -2324,7 +2324,6 @@ selectors. */
 p
 {
   margin-bottom: 0;
-  font-size: 14px;
 }
 
 .upper-section
@@ -2333,7 +2332,6 @@ p
   margin-top: -20px;
   padding-top: 20px;
 }
-
 
 .lower-section
 {


### PR DESCRIPTION
*Issue #: #1000 *

*Description of changes:*

@katiemcgoff and I just noticed this morning that the corpname component didn't reflect the larger fonts requested.

Updated that, and also removed the p font in main.css that I had added the last Friday and meant to take out but ran it over with one of my merges/rebases


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
