### PR TITLE
search page update to NR/Examiner/Comp name fields

### DIFF
--- a/client/src/components/application/Find/findFilter.vue
+++ b/client/src/components/application/Find/findFilter.vue
@@ -200,20 +200,26 @@ export default {
     },
     nrSearch: {
       handler(nrNum) {
-        this.updateQuery('nrNum',nrNum);
-        this.query.offset = 0;
+        if (nrNum.length < 1 || nrNum.length > 2) {
+          this.updateQuery('nrNum', nrNum);
+          this.query.offset = 0;
+        }
       }
     },
     username: {
       handler(activeUser) {
-        this.updateQuery('activeUser',activeUser);
-        this.query.offset = 0;
+        if (activeUser.length < 1 || activeUser.length > 2) {
+          this.updateQuery('activeUser', activeUser);
+          this.query.offset = 0;
+        }
       }
     },
     compName: {
       handler(compName) {
-        this.updateQuery('compName',compName);
-        this.query.offset = 0;
+        if (compName.length < 1 || compName.length > 2) {
+          this.updateQuery('compName', compName);
+          this.query.offset = 0;
+        }
       }
     },
     // priorityCheckBox: {


### PR DESCRIPTION
*Issue #1047:*

*Description of changes:*
nr/examiner/compname do not fire off request until > 3 chars are in their string (unless they are cleared)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
