### PR TITLE
Issue #993 stuck conditions

### DIFF
--- a/client/src/components/application/Examine/CompName.vue
+++ b/client/src/components/application/Examine/CompName.vue
@@ -367,6 +367,7 @@
       },
       nameReject() {
         this.$store.commit('decision_made', 'REJECTED');
+        this.$store.commit('currentCondition', null);
       },
       reOpen() {
         this.$store.state.currentState = 'INPROGRESS';

--- a/client/src/components/application/Examine/CompName.vue
+++ b/client/src/components/application/Examine/CompName.vue
@@ -363,6 +363,7 @@
       },
       nameAccept() {
         this.$store.commit('decision_made', 'APPROVED');
+        this.$store.commit('currentCondition', null);
       },
       nameReject() {
         this.$store.commit('decision_made', 'REJECTED');

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -185,8 +185,8 @@ export default new Vuex.Store({
                     conditional: {response: {numfound: ''}},
                     rejected: {response: {numfound: ''}}
     }
-},
-mutations: {
+  },
+  mutations: {
     requestType (state, value) {
       state.compInfo.requestType = value;
     },


### PR DESCRIPTION
*Issue #: #993 *

*Description of changes:*

- Clear the  condition when the examiner accepts the name.  This way it is gone when they go to getNext, or go back and examine the next name, but it remains when they go back without accepting.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
