### PR TITLE
Handle empty comments better (null rather than '') so blank comment doesn't flash on screen.

### DIFF
--- a/client/src/components/application/Examine/InternalComments.vue
+++ b/client/src/components/application/Examine/InternalComments.vue
@@ -74,7 +74,7 @@
         console.log('got here to addNewComment() in InternalComments component');
 
         // do nothing if comment is blank
-        if (this.newComment == '') return;
+        if (this.newComment == '' || this.newComment == null) return;
 
         // create new comment object with just text, and add it to list of comments in data structure
         var newCommentData = {

--- a/client/src/components/application/Examine/RequestInfoHeader.vue
+++ b/client/src/components/application/Examine/RequestInfoHeader.vue
@@ -663,6 +663,9 @@ export default {
       },
       addNewComment() {
 
+        // do nothing if comment is blank
+        if (this.newComment == '' || this.newComment == null) return;
+
         // create new comment object with just text, and add it to list of comments in data structure
         var newCommentData = {
           comment: this.newComment,


### PR DESCRIPTION
*Issue #:* #1055 

*Description of changes:*
Handle empty comments better (null rather than '') so blank comment doesn't flash on screen.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
