### PR TITLE
Add a ( No Data ) indicator to empty History List and empty Conflict …

### DIFF
--- a/client/src/components/application/Examine/Recipe/conflicts/ConflictList.vue
+++ b/client/src/components/application/Examine/Recipe/conflicts/ConflictList.vue
@@ -3,14 +3,15 @@
 
     <div class="col conflict-list-parent-col">
       <div class="row conflict-list-view">
-
-        <select v-model="selectedConflict" class="form-control" size="17" border="0"
+        <select v-if="conflictData.length > 0"  v-model="selectedConflict" class="form-control" size="17" border="0"
                 @click="check_deselect" tabindex="2">
           <option v-for="option in conflictData" :key="option.value"
             v-bind:value="{nrNumber: option.nrNumber, text: option.text, source: option.source}">
             {{ option.text }}
           </option>
+
         </select>
+        <div v-else class="empty-list">( No data )</div>
 
       </div>
 
@@ -81,6 +82,7 @@
 
   .conflict-list-view {
     padding: 0 10px;
+    height: 100%;
   }
 
   .conflict-list-view option {

--- a/client/src/components/application/Examine/Recipe/history/historyList.vue
+++ b/client/src/components/application/Examine/Recipe/history/historyList.vue
@@ -4,14 +4,14 @@
     <div class="col history-list-parent-col">
       <div class="row history-list-view">
 
-        <select v-model="selectedHistory" class="form-control" size="17" border="0" @click="check_deselect" tabindex="6">
+        <select v-if="historyJSON.names.length > 0" v-model="selectedHistory" class="form-control" size="17" border="0" @click="check_deselect" tabindex="6">
           <option style="margin: 1px" v-for="option in historyJSON.names"
                   v-bind:class="{fail: check_status(option)=='fail', pass: check_status(option)=='pass'}"
                   :key="option.value" v-bind:value="{ name_state_type_cd: option.name_state_type_cd, submit_count: option.submit_count, nr_num: option.nr_num, name: option.name, score: option.score}">
             {{ option.name }}
           </option>
         </select>
-
+        <div v-else class="empty-list">( No data )</div>
       </div>
 
     </div>
@@ -102,6 +102,7 @@
   }
   .history-list-view {
     padding: 0 10px;
+    height: 100%;
   }
 
   .history-list-view option {
@@ -125,5 +126,18 @@
   }
   .border-pass {
     border: 1px solid #b6d7a8;
+  }
+  .empty-list {
+    padding: 5rem;
+    line-height: 1.5;
+    border-radius: .2rem;
+    font-size: 14px;
+    margin-bottom: 2px;
+        color: #6c757d;
+    background-color: #f2f2f2;
+    background-clip: padding-box;
+    border: 1px solid #ced4da;
+    width: 100%;
+    text-align: center;
   }
 </style>


### PR DESCRIPTION
…List

*Issue #:1157*

*Description of changes:*
Conditionally render the history list and the conflict list:  If the data size is 0 then render the 'empty-list' styled div instead of the select element.
Made the style similar to the empty tables for conditions and trademarks (font-color, background color, wording)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
