### PR TITLE
1159 - we now send encoded query to /exact-match

### DIFF
--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -1342,8 +1342,10 @@ export default new Vuex.Store({
 
       console.log('action: getting exact matches for number: ' + state.compInfo.nrNumber + ' from solr')
       const myToken = sessionStorage.getItem('KEYCLOAK_TOKEN')
-      console.log('query', query.substring(1))
-      const url = '/api/v1/exact-match?query='+query.substring(1)
+      query = query.substring(0, 1) == '+' ? query.substring(1) : query;
+      query = encodeURIComponent(query)
+      console.log('query', query)
+      const url = '/api/v1/exact-match?query='+query
       console.log('URL:' + url)
       const vm = this
       return axios.get(url, {headers: {Authorization: `Bearer ${myToken}`}}).then(response => {

--- a/client/test/unit/specs/ExactMatchesRequest.spec.js
+++ b/client/test/unit/specs/ExactMatchesRequest.spec.js
@@ -1,0 +1,57 @@
+import sinon from 'sinon';
+import axios from '@/axios-auth.js';
+import store from '@/store'
+
+describe('store > checkManualExactMatches', () => {
+
+    let sandbox;
+
+    beforeEach(() => {
+        sinon.restore()
+        sandbox = sinon.createSandbox()
+        jest.setTimeout(100000);
+    })
+    afterEach(()=>{
+        sandbox.restore()
+    })
+
+    it('removes the leading plus', (done)=>{
+        sandbox.getStub = sandbox.stub(axios, 'get');
+        sandbox.getStub.withArgs('/api/v1/exact-match?query=dog', sinon.match.any).returns(
+            new Promise((resolve) => resolve({ data: { names:[{ name:'any-name' }] } }))
+        )
+        store.dispatch('checkManualExactMatches', '+dog')
+
+        setTimeout(()=>{
+            expect(store.state.exactMatchesConflicts).toEqual([{ text:'any-name' }])
+            done();
+        }, 300)
+    })
+
+    it('keeps query as-is when there is no leading plus', (done)=>{
+        sandbox.getStub = sandbox.stub(axios, 'get');
+        sandbox.getStub.withArgs('/api/v1/exact-match?query=dog', sinon.match.any).returns(
+            new Promise((resolve) => resolve({ data: { names:[{ name:'any-name' }] } }))
+        )
+        store.dispatch('checkManualExactMatches', 'dog')
+
+        setTimeout(()=>{
+            expect(store.state.exactMatchesConflicts).toEqual([{ text:'any-name' }])
+            done();
+        }, 300)
+    })
+
+    it('encodes the query', (done)=>{
+        sandbox.getStub = sandbox.stub(axios, 'get');
+        sandbox.getStub.withArgs('/api/v1/exact-match?query=dog%26cat', sinon.match.any).returns(
+            new Promise((resolve) => resolve({ data: { names:[{ name:'any-name' }] } }))
+        )
+        store.dispatch('checkManualExactMatches', 'dog&cat')
+
+        setTimeout(()=>{
+            expect(store.state.exactMatchesConflicts).toEqual([{ text:'any-name' }])
+            done();
+        }, 300)
+    })
+
+})


### PR DESCRIPTION
*Issue #:*

*Description of changes:*
we now send encoded query to /exact-match
we also remove the leading plus if any

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
