### PR TITLE
Issue ##1157 bcgov/entity/#17 indicate no results

### DIFF
--- a/client/src/components/application/Examine/CompName.vue
+++ b/client/src/components/application/Examine/CompName.vue
@@ -66,8 +66,8 @@
                 <span class="name-state-icon" v-html="setIcon(compName1.state)"></span>
                 <button class="btn btn-undo" v-if="is_undoable_1"
                         v-on:click="undoDecision(1)">Undo Decision</button>
-                <span id="decision-text1" class="decision-text"
-                        v-bind:class="{'completed-decision-text': is_complete}">{{ compName1.decision_text }}</span>
+                <span class="decision-text"
+                        v-bind:class="{'completed-decision-text': is_complete}">{{ decision_1 }}</span>
               </td>
             </tr>
             <tr class="name-option"
@@ -79,8 +79,8 @@
                 <span class="name-state-icon" v-html="setIcon(compName2.state)"></span>
                 <button class="btn btn-undo" v-if="is_undoable_2"
                         v-on:click="undoDecision(2)">Undo Decision</button>
-                <span id="decision-text2" class="decision-text"
-                        v-bind:class="{'completed-decision-text': is_complete}">{{ compName2.decision_text }}</span>
+                <span class="decision-text"
+                        v-bind:class="{'completed-decision-text': is_complete}">{{ decision_2 }}</span>
               </td>
             </tr>
             <tr class="name-option"
@@ -93,7 +93,7 @@
                 <button class="btn btn-undo" v-if="is_undoable_3"
                         v-on:click="undoDecision(3)">Undo Decision</button>
                 <span id="decision-text3" class="decision-text"
-                      v-bind:class="{'completed-decision-text': is_complete}">{{ compName3.decision_text }}</span>
+                      v-bind:class="{'completed-decision-text': is_complete}">{{ decision_3 }}</span>
               </td>
             </tr>
           </table>
@@ -249,6 +249,15 @@
       compName3State() {
         return this.$store.getters.compName3.state;
       },
+       decision_1() {
+        return this.decisionReasonOrConflictList(this.compName1);
+      },
+       decision_2() {
+        return this.decisionReasonOrConflictList(this.compName2);
+      },
+       decision_3() {
+        return this.decisionReasonOrConflictList(this.compName3);
+      },
       currentNameObj: {
         get: function() {
           return this.$store.getters.currentNameObj;
@@ -332,6 +341,42 @@
       this.setManualSearchStr(this.currentName);
     },
     methods: {
+      /**
+       * decisionReasonOrConflictList:  gets the decision reason(s) whether or not there's anything in the decision text field.
+       * In some older NRs, there is no decision reason text.  In these cases we want to display the list of conflicts instead.
+       */
+       decisionReasonOrConflictList: function (compname) {
+
+          if (!compname) {
+              return;
+          }
+
+          if (this.is_complete) {
+
+              if (compname.decision_text) {
+                return compname.decision_text;
+              } else {
+                return this.getConflictList(compname);
+              }
+          } else {
+              return compname.decision_text
+          }
+      },
+      getConflictList(compname) {
+          if (!compname.conflict1) {
+              return;
+          }
+
+          let reasons = `Rejected due to conflicts:\n${compname.conflict1}`;
+          if (compname.conflict2) {
+              reasons += ", " + compname.conflict2;
+          }
+          if (compname.conflict3) {
+              reasons += ", " + compname.conflict3;
+          }
+
+          return reasons;
+      },
       getNextCompany() {
         this.$store.dispatch('resetValues');
         this.searching = true;
@@ -494,10 +539,8 @@
         console.log('compName1 watcher fired:' + val)
         if (this.resetting) {
           if (this.compName2 != undefined && this.compName2State != 'NE') {
-            console.log("***** Resetting");
             this.$store.dispatch('resetDecision', 2);
           } else {
-            console.log("***** Not Resetting?")
             this.addNewComment(this.add_comment_display);
           }
         }

--- a/client/test/jest/ComponentSnapshotTests/application/examine/__snapshots__/CompName.spec.js.snap
+++ b/client/test/jest/ComponentSnapshotTests/application/examine/__snapshots__/CompName.spec.js.snap
@@ -74,7 +74,6 @@ exports[`CompName.vue  renders a CompName component 1`] = `
                
               <span
                 class="decision-text"
-                id="decision-text1"
               >
                 
               </span>
@@ -102,7 +101,6 @@ exports[`CompName.vue  renders a CompName component 1`] = `
                
               <span
                 class="decision-text"
-                id="decision-text2"
               >
                 
               </span>

--- a/client/test/unit/specs/CompName.spec.js
+++ b/client/test/unit/specs/CompName.spec.js
@@ -93,4 +93,41 @@ describe('CompName.vue', () => {
         })
     })
 
+    describe('Display conflicts if there is no decision reason', ()=> {
+      let sandbox;
+      let vm;
+
+      beforeEach((done) => {
+        sandbox = sinon.createSandbox();
+        instance.$store.state.currentState = 'APPROVED';
+        instance.$store.state.compInfo.compNames = {
+          compName1:
+            {
+              choice: 1,
+              name: "Bad Name",
+              state: 'REJECTED',
+              decision_text: "",
+              conflict1: "Bada Boom Bad Name",
+              conflict2: "Bad Dudes Name",
+            },
+          compName2: { choice: 2, name: "Good Name", state: 'ACCEPTED' },
+          compName3: { choice: 3, name: null, state: 'NE' }
+        };
+        vm = instance.$mount();
+        setTimeout(() => {
+          done();
+        }, 100)
+      });
+
+      afterEach(() => {
+        sandbox.restore()
+      });
+
+      it('displays conflicts when there are no deision reasons', () => {
+        expect(vm.$el.querySelectorAll('.completed-decision-text')).not.toBeNull();
+        expect(vm.$el.querySelectorAll('.completed-decision-text')[0].innerHTML).toContain('Bada Boom Bad Name');
+        expect(vm.$el.querySelectorAll('.completed-decision-text')[0].innerHTML).toContain('Bad Dudes Name');
+      })
+    })
+
 });


### PR DESCRIPTION
*Issue #: bcgov/entity/#17*

*Description of changes:*

* Added tests for the case when the data has no decision text in the compname.  
* Updated the decision display so that it shows the conflicts instead of the decision reason if there is no decision reason given.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
