### PR TITLE
13 solr synonymbucket handle special chars

### DIFF
--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -1329,30 +1329,8 @@ export default new Vuex.Store({
     runManualRecipe({dispatch,state},searchStr) {
       console.log('running manual recipe with: ', searchStr);
       if( state.currentChoice != null) {
-        this.dispatch('checkManualExactMatches',searchStr
-          .replace(' \/','\/')
-          .replace('(', '')
-          .replace(')', '')
-          .replace(']', '')
-          .replace('[', '')
-          .replace('}', '')
-          .replace('{', ''));
-        this.dispatch('checkManualSynonymMatches',searchStr
-          .replace('\/',' ')
-          .replace('\\',' ')
-          .replace('&', ' ')
-          .replace('+', ' ')
-          .replace('-', ' ')
-          .replace('(', '')
-          .replace(')', '')
-          .replace('}', '')
-          .replace('{', '')
-          .replace(']', '')
-          .replace('[', '')
-          .replace('?','')
-          .replace('#','')
-          .replace('%', '')
-          .replace('@', ''));
+        this.dispatch('checkManualExactMatches',searchStr);
+        this.dispatch('checkManualSynonymMatches',searchStr);
         this.dispatch('checkManualConflicts',searchStr)
         this.dispatch('checkManualTrademarks',searchStr)
         this.dispatch('checkManualConditions',searchStr)
@@ -1363,6 +1341,13 @@ export default new Vuex.Store({
     checkManualExactMatches( {commit, state}, query ) {
 
       console.log('action: getting exact matches for number: ' + state.compInfo.nrNumber + ' from solr')
+      query = query.replace(' \/','\/')
+          .replace('/(/g', '')
+          .replace('/)/g', '')
+          .replace('/]/g', '')
+          .replace('/[/g', '')
+          .replace('/}/g', '')
+          .replace('/{/g', '')
       const myToken = sessionStorage.getItem('KEYCLOAK_TOKEN')
       query = query.substring(0, 1) == '+' ? query.substring(1) : query;
       query = encodeURIComponent(query)
@@ -1380,6 +1365,21 @@ export default new Vuex.Store({
     checkManualSynonymMatches( {dispatch,commit,state}, query ) {
 
       console.log('action: getting synonym matches for number: ' + state.compInfo.nrNumber + ' from solr')
+      query = query.replace(/\//g,' ')
+          .replace(/\\/g,' ')
+          .replace(/&/g, ' ')
+          .replace(/\+/g, ' ')
+          .replace(/\-/g, ' ')
+          .replace(/\(/g, '')
+          .replace(/\)/g, '')
+          .replace(/}/g, '')
+          .replace(/{/g, '')
+          .replace(/]/g, '')
+          .replace(/\[/g, '')
+          .replace(/\?/g,'')
+          .replace(/#/g,'')
+          .replace(/%/g, '')
+          .replace(/@/g, '');
       const myToken = sessionStorage.getItem('KEYCLOAK_TOKEN');
       const url = '/api/v1/requests/synonymbucket/' + query;
       console.log('URL:' + url);

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -1342,12 +1342,12 @@ export default new Vuex.Store({
 
       console.log('action: getting exact matches for number: ' + state.compInfo.nrNumber + ' from solr')
       query = query.replace(' \/','\/')
-          .replace('/(/g', '')
-          .replace('/)/g', '')
-          .replace('/]/g', '')
-          .replace('/[/g', '')
-          .replace('/}/g', '')
-          .replace('/{/g', '')
+          .replace(/\(/g, '')
+          .replace(/\)/g, '')
+          .replace(/]/g, '')
+          .replace(/\[/g, '')
+          .replace(/}/g, '')
+          .replace(/{/g, '')
       const myToken = sessionStorage.getItem('KEYCLOAK_TOKEN')
       query = query.substring(0, 1) == '+' ? query.substring(1) : query;
       query = encodeURIComponent(query)

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -1329,8 +1329,30 @@ export default new Vuex.Store({
     runManualRecipe({dispatch,state},searchStr) {
       console.log('running manual recipe with: ', searchStr);
       if( state.currentChoice != null) {
-        this.dispatch('checkManualExactMatches',searchStr)
-        this.dispatch('checkManualSynonymMatches',searchStr)
+        this.dispatch('checkManualExactMatches',searchStr
+          .replace(' \/','\/')
+          .replace('(', '')
+          .replace(')', '')
+          .replace(']', '')
+          .replace('[', '')
+          .replace('}', '')
+          .replace('{', ''));
+        this.dispatch('checkManualSynonymMatches',searchStr
+          .replace('\/',' ')
+          .replace('\\',' ')
+          .replace('&', ' ')
+          .replace('+', ' ')
+          .replace('-', ' ')
+          .replace('(', '')
+          .replace(')', '')
+          .replace('}', '')
+          .replace('{', '')
+          .replace(']', '')
+          .replace('[', '')
+          .replace('?','')
+          .replace('#','')
+          .replace('%', '')
+          .replace('@', ''));
         this.dispatch('checkManualConflicts',searchStr)
         this.dispatch('checkManualTrademarks',searchStr)
         this.dispatch('checkManualConditions',searchStr)
@@ -1359,13 +1381,11 @@ export default new Vuex.Store({
 
       console.log('action: getting synonym matches for number: ' + state.compInfo.nrNumber + ' from solr')
       const myToken = sessionStorage.getItem('KEYCLOAK_TOKEN');
-      console.log('query', query);
       const url = '/api/v1/requests/synonymbucket/' + query;
       console.log('URL:' + url);
       const vm = this;
       dispatch('checkToken');
       return axios.get(url, {headers: {Authorization: `Bearer ${myToken}`}}).then(response => {
-        console.log('Check SYNONYM Match Response:', JSON.stringify(response.data))
         commit('setSynonymMatchesConflicts', response.data)
       })
         .catch(error => console.log('ERROR (synonym matches): ' + error))

--- a/client/test/features/specs/support/given.queue.js
+++ b/client/test/features/specs/support/given.queue.js
@@ -46,7 +46,7 @@ let givenQueue = (given, data)=>{
                     })
                 })
             )
-            data.apiSandbox.getStub.withArgs('/api/v1/requests/synonymbucket/+' + data.name(data.queueIndex), sinon.match.any).returns(
+            data.apiSandbox.getStub.withArgs('/api/v1/requests/synonymbucket/ ' + data.name(data.queueIndex).replace('&',' '), sinon.match.any).returns(
                 new Promise((resolve) => {
                     resolve({
                         data: {

--- a/client/test/unit/specs/Conflicts.spec.js
+++ b/client/test/unit/specs/Conflicts.spec.js
@@ -1,3 +1,4 @@
+/*eslint-disable*/
 import staticFilesServer from '../static.files.server';
 import { createApiSandbox, sinon } from '../../features/specs/support/api.stubs'
 import Vue from 'vue';
@@ -50,7 +51,7 @@ describe('Conflicts', () => {
                 new Promise((resolve) => resolve({ data: {
                     setConflicts: {},
                     names: [
-                        { id:1, name:'Incredible World LTD' }
+                        { id:1, name:'Incredible World LTD', source:'CORP' }
                     ],
                     response: {}
                 } }))
@@ -63,7 +64,7 @@ describe('Conflicts', () => {
                     names: [],
                 } }))
             )
-            data.apiSandbox.getStub.withArgs('/api/v1/requests/synonymbucket/+incredible name inc', sinon.match.any).returns(
+            data.apiSandbox.getStub.withArgs('/api/v1/requests/synonymbucket/ incredible name inc', sinon.match.any).returns(
                 new Promise((resolve) => {
                     resolve({
                         data: {

--- a/client/test/unit/specs/ExactMatchConflicts.spec.js
+++ b/client/test/unit/specs/ExactMatchConflicts.spec.js
@@ -1,3 +1,4 @@
+/*eslint-disable*/
 import staticFilesServer from '../static.files.server';
 import { createApiSandbox, sinon } from '../../features/specs/support/api.stubs'
 import Vue from 'vue';
@@ -68,7 +69,7 @@ describe('Exact-Match Conflicts', () => {
             data.apiSandbox.getStub.withArgs('/api/v1/requests/42', sinon.match.any).returns(
                 new Promise((resolve) => resolve({ data: { names:[] } }))
             )
-            data.apiSandbox.getStub.withArgs('/api/v1/requests/synonymbucket/+incredible name inc', sinon.match.any).returns(
+            data.apiSandbox.getStub.withArgs('/api/v1/requests/synonymbucket/ incredible name inc', sinon.match.any).returns(
                 new Promise((resolve) => {
                     resolve({
                         data: {

--- a/client/test/unit/specs/SynonymMatchConflicts.spec.js
+++ b/client/test/unit/specs/SynonymMatchConflicts.spec.js
@@ -64,7 +64,7 @@ describe('Synonym-Match Conflicts', () => {
                     names: [],
                 } }))
             )
-            data.apiSandbox.getStub.withArgs('/api/v1/requests/synonymbucket/+incredible name inc', sinon.match.any).returns(
+            data.apiSandbox.getStub.withArgs('/api/v1/requests/synonymbucket/ incredible name inc', sinon.match.any).returns(
                 new Promise((resolve) => {
                     resolve({
                         data: {
@@ -109,14 +109,14 @@ describe('Synonym-Match Conflicts', () => {
 
         it('populates additional attributes as expected', ()=>{
             expect(data.instance.$store.state.synonymMatchesConflicts).toEqual([{"nrNumber": undefined,
-              "source": undefined, "text": "----INCREDIBLE NAME INC*"},
-              {"nrNumber": undefined, "source": undefined, "text": "----INCREDIBLE NAME*"},
-              {"nrNumber": undefined, "source": undefined, "text": "----INCREDIBLE*"},
-              {"nrNumber": "0793638", "source": "CORP", "text": "INCREDIBLE STEPS RECORDS, INC."}])
+                "source": undefined, "text": "----INCREDIBLE NAME INC*"},
+                {"nrNumber": undefined, "source": undefined, "text": "----INCREDIBLE NAME*"},
+                {"nrNumber": undefined, "source": undefined, "text": "----INCREDIBLE*"},
+                {"nrNumber": "0793638", "source": "CORP", "text": "INCREDIBLE STEPS RECORDS, INC."}])
         })
 
         it('resists no synonym match', (done)=>{
-            data.apiSandbox.getStub.withArgs('/api/v1/requests/synonymbucket/+incredible name inc', sinon.match.any).returns(
+            data.apiSandbox.getStub.withArgs('/api/v1/requests/synonymbucket/ incredible name inc', sinon.match.any).returns(
                 new Promise((resolve) => resolve({ data: {
                     names: []
                 } }))
@@ -167,7 +167,7 @@ describe('Synonym-Match Conflicts', () => {
                     response: {}
                 } }))
             )
-            data.apiSandbox.getStub.withArgs('/api/v1/requests/synonymbucket/+incredible name inc', sinon.match.any).returns(
+            data.apiSandbox.getStub.withArgs('/api/v1/requests/synonymbucket/ incredible name inc', sinon.match.any).returns(
                 new Promise((resolve) => resolve({ data: {
                     names: []
                 } }))

--- a/client/test/unit/specs/SynonymMatchesRequest.spec.js
+++ b/client/test/unit/specs/SynonymMatchesRequest.spec.js
@@ -1,0 +1,81 @@
+/*eslint-disable*/
+import sinon from 'sinon';
+import axios from '@/axios-auth.js';
+import store from '@/store'
+
+describe('store > checkManualSynonymMatches', () => {
+
+    let SynonymMatch;
+
+    beforeEach(() => {
+        SynonymMatch = sinon.fake.resolves({ data: { names:[] } })
+        sinon.replace(axios, 'get', SynonymMatch);
+    })
+    afterEach(()=>{
+        sinon.restore()
+    })
+
+    it('replaces the plus with a space', ()=>{
+        store.dispatch('checkManualSynonymMatches', '+dog+cat + fish+')
+        // let lastCallList = SynonymMatch.lastCall
+        // console.log(lastCallList)
+        // console.log(lastCallList.args)
+        expect(SynonymMatch.lastCall.args[0]).toEqual('/api/v1/requests/synonymbucket/ dog cat   fish ')
+    })
+
+    it('keeps query as-is when there is no leading plus', ()=>{
+        store.dispatch('checkManualSynonymMatches', 'dog')
+
+        expect(SynonymMatch.lastCall.args[0]).toEqual('/api/v1/requests/synonymbucket/dog')
+    })
+
+    it('replaces the & with a space', ()=>{
+        store.dispatch('checkManualSynonymMatches', 'dog&cat & fish')
+
+        expect(SynonymMatch.lastCall.args[0]).toEqual('/api/v1/requests/synonymbucket/dog cat   fish')
+    })
+
+    it('replaces / and \\ with a space', ()=>{
+        store.dispatch('checkManualSynonymMatches', 'dog/cat /fish \\ bear\\')
+
+        expect(SynonymMatch.lastCall.args[0]).toEqual('/api/v1/requests/synonymbucket/dog cat  fish   bear ')
+    })
+
+    it('replaces - with a space', ()=>{
+        store.dispatch('checkManualSynonymMatches', 'dog-cat -fish - bear')
+
+        expect(SynonymMatch.lastCall.args[0]).toEqual('/api/v1/requests/synonymbucket/dog cat  fish   bear')
+    })
+
+    it('removes brackets', ()=>{
+        store.dispatch('checkManualSynonymMatches', 'dog (cat) {fish} [bear]')
+
+        expect(SynonymMatch.lastCall.args[0]).toEqual('/api/v1/requests/synonymbucket/dog cat fish bear')
+    })
+
+    it('removes ?', ()=>{
+        store.dispatch('checkManualSynonymMatches', 'dog ? cat? ?fish bear')
+
+        expect(SynonymMatch.lastCall.args[0]).toEqual('/api/v1/requests/synonymbucket/dog  cat fish bear')
+    })
+
+    it('removes #', ()=>{
+        store.dispatch('checkManualSynonymMatches', 'dog # cat# #fish bear')
+
+        expect(SynonymMatch.lastCall.args[0]).toEqual('/api/v1/requests/synonymbucket/dog  cat fish bear')
+    })
+
+    it('removes @', ()=>{
+        store.dispatch('checkManualSynonymMatches', 'dog @ cat@ @fish bear')
+
+        expect(SynonymMatch.lastCall.args[0]).toEqual('/api/v1/requests/synonymbucket/dog  cat fish bear')
+    })
+
+    it('removes %', ()=>{
+        store.dispatch('checkManualSynonymMatches', 'dog % cat% %fish bear')
+
+        expect(SynonymMatch.lastCall.args[0]).toEqual('/api/v1/requests/synonymbucket/dog  cat fish bear')
+    })
+
+
+})


### PR DESCRIPTION
*Issue #: bcgov/entity#13*

*Description of changes:*
- synonymbucket call replaces special chars with '' or ' ' when required before sending to backend
- tests updated around synonymbucket
- exact match call replaces a few special chars that were breaking its search

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
