### PR TITLE
22 - bug fix on conflicts icon toggle

### DIFF
--- a/client/src/components/application/Examine/RecipeMenu.vue
+++ b/client/src/components/application/Examine/RecipeMenu.vue
@@ -63,9 +63,6 @@ export default {
     synonymMatchesInfo() {
       return this.$store.getters.synonymMatchesConflicts;
     },
-    conflictsInfo() {
-      return this.$store.getters.conflictsJSON;
-    },
     conditionInfo() {
       return this.$store.getters.conditionsJSON;
     },
@@ -83,26 +80,16 @@ export default {
     hasSynConflicts() {
       let synMatchesList = this.synonymMatchesInfo;
       for (let i=0; i<synMatchesList.length; i++) {
-        if (synMatchesList[i].source)
+        if (synMatchesList[i].source != undefined)
           return true;
       }
       return false;
     },
     setConflicts() {
-        var hasConflicts = true;
-        var hasExactConflicts = this.hasExactMatchesInfo;
-        if (!hasExactConflicts && !this.hasSynConflicts()) {
-            hasConflicts =
-                this.conflictsInfo !== null
-                && this.conflictsInfo != undefined
-                && this.conflictsInfo.names.length > 0
-        }
-        if (hasConflicts) {
-            this.setFail('Conflict')
-        }
-        else {
-            this.setPass('Conflict')
-        }
+      if (this.hasExactMatchesInfo || this.hasSynConflicts())
+        this.setFail('Conflict');
+      else
+        this.setPass('Conflict');
     },
     setConditions() {
       // if no restricted words -> call setPass
@@ -207,7 +194,7 @@ export default {
     }
   },
   watch: {
-    conflictsInfo: function (val) {
+    synonymMatchesInfo: function (val) {
       // set severity flag on recipe menu
       this.setConflicts();
     },


### PR DESCRIPTION
Signed-off-by: Kial Jinnah <kialj876@gmail.com>

*Issue #:bcgov/entity#22*

*Description of changes:*
- set conflicts function (which toggles the conflict recipe menu icon) was firing based on old conflict list watcher. Changed to fire off of synonym bucket or exact match

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
