### PR TITLE
removed @ strip

### DIFF
--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -1325,7 +1325,6 @@ export default new Vuex.Store({
           .replace(/\?/g,'')
           .replace(/#/g,'')
           .replace(/%/g, '')
-          .replace(/@/g, '');
       const myToken = sessionStorage.getItem('KEYCLOAK_TOKEN');
       const url = '/api/v1/requests/synonymbucket/' + query;
       console.log('URL:' + url);


### PR DESCRIPTION
*Issue #:13*

*Description of changes:*
- no longer strip '@' in synonym bucket search

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
