### PR TITLE
30 - preserve DRAFT state upon edit (ie: don't lose place in queue).

### DIFF
--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -26,6 +26,7 @@ export default new Vuex.Store({
       choice: null,
     },
     currentState: null, // NR - APPROVED, REJECTED, INPROGRESS ETC...
+    previousStateCd: null,
 
     currentConflict: null, // the conflict name currently in focus
     currentCondition: null, // the condition currently in focus
@@ -467,6 +468,7 @@ export default new Vuex.Store({
 
       console.log('Still loading')
       state.currentState = dbcompanyInfo.state;
+      state.previousStateCd = dbcompanyInfo.previousStateCd;
       state.compInfo.requestType = dbcompanyInfo.requestTypeCd
 
 
@@ -679,6 +681,7 @@ export default new Vuex.Store({
       if (state.additionalCompInfo.nwpta_ab.partnerJurisdictionTypeCd !== null) state.nrData.nwpta.push(state.additionalCompInfo.nwpta_ab);
       if (state.additionalCompInfo.nwpta_sk.partnerJurisdictionTypeCd !== null) state.nrData.nwpta.push(state.additionalCompInfo.nwpta_sk);
       state.nrData.state =  state.currentState
+      state.nrData.previousStateCd = state.previousStateCd;
       state.nrData.userId = state.examiner
       state.nrData.priorityCd = state.priority
       //state.reservationCount = dbcompanyInfo.reservationCount

--- a/client/test/unit/specs/RequestInfoHeader.spec.js
+++ b/client/test/unit/specs/RequestInfoHeader.spec.js
@@ -89,6 +89,7 @@ describe('RequestInfoHeader.vue', () => {
               nwpta: [],
               previousNr: null,
               previousRequestId: null,
+              previousStateCd: null,
               priorityCd: "Y",
               requestTypeCd: "CR",
               state: "INPROGRESS",
@@ -154,6 +155,7 @@ describe('RequestInfoHeader.vue', () => {
               nwpta: [],
               previousNr: null,
               previousRequestId: null,
+              previousStateCd: null,
               priorityCd: "Y",
               requestTypeCd: "CR",
               state: "INPROGRESS",
@@ -207,19 +209,394 @@ describe('RequestInfoHeader.vue', () => {
         console.log('END details')
       }, 10)
     });
+  });
 
-    it('has the edit button working properly', () => {
-      console.log('START edit')
-      expect(vm.is_my_current_nr).toBeTruthy();
-      expect(vm.can_edit).toBeTruthy();
-      expect(vm.$el.querySelector('#nr-details-edit-button').textContent).toEqual('Edit');
-      click('#nr-details-edit-button');
-      setTimeout(() => {
-        expect(vm.$el.querySelector('#nr-details-edit-button')).toBeNull();
+  describe('Testing Editing the NR in DRAFT (unexamined)', () => {
+    let vm;
+    let sandbox;
+
+    let putCall, getCall, patchCall;
+
+    let click = function(id) {
+      console.log('ID: ',id)
+      let button = vm.$el.querySelector(id);
+      let window = button.ownerDocument.defaultView;
+      var click = new window.Event('click');
+      button.dispatchEvent(click);
+    };
+    beforeEach((done) => {
+
+      sandbox = sinon.createSandbox();
+      putCall = sandbox.stub(axios, 'put').withArgs('/api/v1/requests/NR 2000950', sinon.match.any).returns(
+        new Promise((resolve) => resolve({
+          data:
+            {
+              additionalInfo: "More info",
+              applicants:
+                {
+                  addrLine1: "940 Blanshard Street",
+                  addrLine2: null,
+                  addrLine3: null,
+                  city: "Victoria",
+                  clientFirstName: null,
+                  clientLastName: null,
+                  contact: "John Test",
+                  countryTypeCd: "CA",
+                  declineNotificationInd: null,
+                  emailAddress: "testoutputs@gov.bc.ca",
+                  faxNumber: null,
+                  firstName: "John",
+                  lastName: "Test",
+                  middleName: null,
+                  partyId: 1822,
+                  phoneNumber: "2505555555",
+                  postalCd: "V8V4K8",
+                  stateProvinceCd: "BC"
+                },
+              comments: [],
+              consentFlag: null,
+              corpNum: null,
+              expirationDate: null,
+              furnished: "N",
+              id: 1822,
+              lastUpdate: "Thu, 18 Oct 2018 22:46:54 GMT",
+              names: [
+                {
+                  choice: 1,
+                  comment: null,
+                  conflict1: "",
+                  conflict1_num: "",
+                  conflict2: "",
+                  conflict2_num: "",
+                  conflict3: "",
+                  conflict3_num: "",
+                  consumptionDate: null,
+                  decision_text: "",
+                  name: "COLDSTREAM REFRIGERATION  HVAC SERVICES LIMITED",
+                  state: "NE"
+                }],
+              natureBusinessInfo: "Nature of business can be pretty long so this one is more realistic. It even contains " +
+                "spaces and punctuation.",
+              nrNum: "NR 2000950",
+              nwpta: [],
+              previousNr: null,
+              previousRequestId: null,
+              previousStateCd: null,
+              priorityCd: "Y",
+              requestTypeCd: "CR",
+              state: "DRAFT",
+              submitCount: 1,
+              submittedDate: "Wed, 17 Oct 2018 11:37:20 GMT",
+              submitter_userid: "",
+              userId: "tester",
+              xproJurisdiction: null
+            }
+          }))
+      );
+      getCall = sandbox.stub(axios, 'get').withArgs('/api/v1/requests/NR 2000950', sinon.match.any).returns(
+        new Promise((resolve) => resolve({
+          data:
+            {
+              additionalInfo: "More info",
+              applicants:
+                {
+                  addrLine1: "940 Blanshard Street",
+                  addrLine2: null,
+                  addrLine3: null,
+                  city: "Victoria",
+                  clientFirstName: null,
+                  clientLastName: null,
+                  contact: "John Test",
+                  countryTypeCd: "CA",
+                  declineNotificationInd: null,
+                  emailAddress: "testoutputs@gov.bc.ca",
+                  faxNumber: null,
+                  firstName: "John",
+                  lastName: "Test",
+                  middleName: null,
+                  partyId: 1822,
+                  phoneNumber: "2505555555",
+                  postalCd: "V8V4K8",
+                  stateProvinceCd: "BC"
+                },
+              comments: [],
+              consentFlag: null,
+              corpNum: null,
+              expirationDate: null,
+              furnished: "N",
+              id: 1822,
+              lastUpdate: "Thu, 18 Oct 2018 22:46:54 GMT",
+              names: [
+                {
+                  choice: 1,
+                  comment: null,
+                  conflict1: "",
+                  conflict1_num: "",
+                  conflict2: "",
+                  conflict2_num: "",
+                  conflict3: "",
+                  conflict3_num: "",
+                  consumptionDate: null,
+                  decision_text: "",
+                  name: "COLDSTREAM REFRIGERATION  HVAC SERVICES LIMITED",
+                  state: "NE"
+                }],
+              natureBusinessInfo: "Nature of business can be pretty long so this one is more realistic. It even contains " +
+                "spaces and punctuation.",
+              nrNum: "NR 2000948",
+              nwpta: [],
+              previousNr: null,
+              previousRequestId: null,
+              previousStateCd: "DRAFT",
+              priorityCd: "Y",
+              requestTypeCd: "CR",
+              state: "INPROGRESS",
+              submitCount: 1,
+              submittedDate: "Wed, 17 Oct 2018 11:37:20 GMT",
+              submitter_userid: "",
+              userId: "tester",
+              xproJurisdiction: null
+            }
+          }))
+      );
+      patchCall = sandbox.stub(axios, 'patch').withArgs('/api/v1/requests/NR 2000950', sinon.match.any).returns(
+        new Promise((resolve) => resolve({
+          data:
+            {
+              message: "Request:NR 2000950 - patched"
+            }
+          }))
+      );
+      vm = instance.$mount();
+      vm.$store.commit('setLoginValues');
+      vm.$store.commit('nrNumber','NR 2000950');
+      setTimeout(()=>{
+        done();
+      }, 100)
+    });
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    describe('cancel/save testing', () => {
+
+      beforeEach((done) => {
+        click('#nr-details-edit-button');
+        setTimeout(()=>{
+          done();
+        }, 100)
+      });
+      afterEach((done) => {
+        setTimeout(()=> {
+          done();
+        }, 100)
+      });
+
+      it('has the cancel button working properly', () => {
+        console.log('CANCEL')
+        click('#nr-details-cancel-button');
+        setTimeout(()=> {
+          expect(vm.$el.querySelector('#nr-details-edit-button').textContent).toEqual('Edit');
+          expect(vm.$el.querySelector('#nr-details-save-button')).toBeNull();
+          expect(vm.$el.querySelector('#nr-details-cancel-button')).toBeNull();
+
+          // the PATCH should have been called to revert state to DRAFT
+          expect(patchCall.lastCall).not.toBeNull();
+          expect(patchCall.lastCall.args[1].state).toEqual('DRAFT');
+          expect(patchCall.lastCall.args[1].previousStateCd).toEqual(null);
+
+          console.log('END cancel')
+        }, 10);
+      });
+
+      it('has the save button working properly', () => {
+        console.log('START save')
+
+        expect(vm.validate()).toBeTruthy();
         expect(vm.$el.querySelector('#nr-details-save-button').textContent).toEqual('Save');
-        expect(vm.$el.querySelector('#nr-details-cancel-button').textContent).toEqual('Cancel');
-        console.log('END edit')
-      }, 10);
+        click('#nr-details-save-button');
+
+        setTimeout(() => {
+          expect(vm.$el.querySelector('#nr-details-edit-button').textContent).toEqual('Edit');
+          expect(vm.$el.querySelector('#nr-details-save-button')).toBeNull();
+          expect(vm.$el.querySelector('#nr-details-cancel-button')).toBeNull();
+
+          // the PUT is called, saving state back to DRAFT
+          expect(putCall.lastCall).not.toBeNull();
+          expect(putCall.lastCall.args[1].state).toEqual('DRAFT');
+          expect(putCall.lastCall.args[1].previousStateCd).toEqual(null);
+
+          console.log('finished');
+        });
+      });
+
+    });
+  });
+  describe('Testing Editing the NR in INPROGRESS (my current NR)', () => {
+    let vm;
+    let sandbox;
+
+    let putCall, getCall, patchCall;
+
+    let click = function(id) {
+      console.log('ID: ',id)
+      let button = vm.$el.querySelector(id);
+      let window = button.ownerDocument.defaultView;
+      var click = new window.Event('click');
+      button.dispatchEvent(click);
+    };
+    beforeEach((done) => {
+
+      sandbox = sinon.createSandbox();
+      putCall = sandbox.stub(axios, 'put').withArgs('/api/v1/requests/NR 2000948', sinon.match.any).returns(
+        new Promise((resolve) => resolve({
+          data:
+            {
+              additionalInfo: "More info",
+              applicants:
+                {
+                  addrLine1: "940 Blanshard Street",
+                  addrLine2: null,
+                  addrLine3: null,
+                  city: "Victoria",
+                  clientFirstName: null,
+                  clientLastName: null,
+                  contact: "John Test",
+                  countryTypeCd: "CA",
+                  declineNotificationInd: null,
+                  emailAddress: "testoutputs@gov.bc.ca",
+                  faxNumber: null,
+                  firstName: "John",
+                  lastName: "Test",
+                  middleName: null,
+                  partyId: 1822,
+                  phoneNumber: "2505555555",
+                  postalCd: "V8V4K8",
+                  stateProvinceCd: "BC"
+                },
+              comments: [],
+              consentFlag: null,
+              corpNum: null,
+              expirationDate: null,
+              furnished: "N",
+              id: 1822,
+              lastUpdate: "Thu, 18 Oct 2018 22:46:54 GMT",
+              names: [
+                {
+                  choice: 1,
+                  comment: null,
+                  conflict1: "",
+                  conflict1_num: "",
+                  conflict2: "",
+                  conflict2_num: "",
+                  conflict3: "",
+                  conflict3_num: "",
+                  consumptionDate: null,
+                  decision_text: "",
+                  name: "COLDSTREAM REFRIGERATION  HVAC SERVICES LIMITED",
+                  state: "NE"
+                }],
+              natureBusinessInfo: "Nature of business can be pretty long so this one is more realistic. It even contains " +
+                "spaces and punctuation.",
+              nrNum: "NR 2000948",
+              nwpta: [],
+              previousNr: null,
+              previousRequestId: null,
+              previousStateCd: null,
+              priorityCd: "Y",
+              requestTypeCd: "CR",
+              state: "INPROGRESS",
+              submitCount: 1,
+              submittedDate: "Wed, 17 Oct 2018 11:37:20 GMT",
+              submitter_userid: "",
+              userId: "tester",
+              xproJurisdiction: null
+            }
+          }))
+      );
+      getCall = sandbox.stub(axios, 'get').withArgs('/api/v1/requests/NR 2000948', sinon.match.any).returns(
+        new Promise((resolve) => resolve({
+          data:
+            {
+              additionalInfo: "More info",
+              applicants:
+                {
+                  addrLine1: "940 Blanshard Street",
+                  addrLine2: null,
+                  addrLine3: null,
+                  city: "Victoria",
+                  clientFirstName: null,
+                  clientLastName: null,
+                  contact: "John Test",
+                  countryTypeCd: "CA",
+                  declineNotificationInd: null,
+                  emailAddress: "testoutputs@gov.bc.ca",
+                  faxNumber: null,
+                  firstName: "John",
+                  lastName: "Test",
+                  middleName: null,
+                  partyId: 1822,
+                  phoneNumber: "2505555555",
+                  postalCd: "V8V4K8",
+                  stateProvinceCd: "BC"
+                },
+              comments: [],
+              consentFlag: null,
+              corpNum: null,
+              expirationDate: null,
+              furnished: "N",
+              id: 1822,
+              lastUpdate: "Thu, 18 Oct 2018 22:46:54 GMT",
+              names: [
+                {
+                  choice: 1,
+                  comment: null,
+                  conflict1: "",
+                  conflict1_num: "",
+                  conflict2: "",
+                  conflict2_num: "",
+                  conflict3: "",
+                  conflict3_num: "",
+                  consumptionDate: null,
+                  decision_text: "",
+                  name: "COLDSTREAM REFRIGERATION  HVAC SERVICES LIMITED",
+                  state: "NE"
+                }],
+              natureBusinessInfo: "Nature of business can be pretty long so this one is more realistic. It even contains " +
+                "spaces and punctuation.",
+              nrNum: "NR 2000948",
+              nwpta: [],
+              previousNr: null,
+              previousRequestId: null,
+              previousStateCd: null,
+              priorityCd: "Y",
+              requestTypeCd: "CR",
+              state: "INPROGRESS",
+              submitCount: 1,
+              submittedDate: "Wed, 17 Oct 2018 11:37:20 GMT",
+              submitter_userid: "",
+              userId: "tester",
+              xproJurisdiction: null
+            }
+          }))
+      );
+      patchCall = sandbox.stub(axios, 'patch').withArgs('/api/v1/requests/NR 2000948', sinon.match.any).returns(
+        new Promise((resolve) => resolve({
+          data:
+            {
+              message: "Request:NR 2000948 - patched"
+            }
+          }))
+      );
+      vm = instance.$mount();
+      vm.$store.commit('setLoginValues');
+      vm.$store.commit('nrNumber','NR 2000948');
+      setTimeout(()=>{
+        done();
+      }, 100)
+    });
+    afterEach(() => {
+      sandbox.restore();
     });
 
     describe('cancel/save testing', () => {
@@ -235,18 +612,23 @@ describe('RequestInfoHeader.vue', () => {
         }, 100)
       });
 
-      it.skip('has the cancel button working properly', () => {
+      it('has the cancel button working properly', () => {
         console.log('CANCEL')
         click('#nr-details-cancel-button');
         setTimeout(()=> {
           expect(vm.$el.querySelector('#nr-details-edit-button').textContent).toEqual('Edit');
           expect(vm.$el.querySelector('#nr-details-save-button')).toBeNull();
           expect(vm.$el.querySelector('#nr-details-cancel-button')).toBeNull();
+
+          // the PATCH should not have been called (ie: no change in state), just a GET
+          expect(patchCall.lastCall).toBeNull();
+          expect(getCall.lastCall).not.toBeNull();
+
           console.log('END cancel')
         }, 10);
       });
 
-      it.skip('has the save button working properly', () => {
+      it('has the save button working properly', () => {
         console.log('START save')
 
         expect(vm.validate()).toBeTruthy();
@@ -257,11 +639,237 @@ describe('RequestInfoHeader.vue', () => {
           expect(vm.$el.querySelector('#nr-details-edit-button').textContent).toEqual('Edit');
           expect(vm.$el.querySelector('#nr-details-save-button')).toBeNull();
           expect(vm.$el.querySelector('#nr-details-cancel-button')).toBeNull();
+
+          // the PUT is called without changing the state, ie: it's still INPROGRESS
+          expect(putCall.lastCall).not.toBeNull();
+          expect(putCall.lastCall.args[1].state).toEqual('INPROGRESS');
+          expect(putCall.lastCall.args[1].previousStateCd).toEqual(null);
+
           console.log('finished');
         });
       });
-
     });
 
   });
+
+  describe('Testing Editing the NR after complete', () => {
+    let vm;
+    let sandbox;
+
+    let putCall, getCall, patchCall;
+
+    let click = function(id) {
+      console.log('ID: ',id)
+      let button = vm.$el.querySelector(id);
+      let window = button.ownerDocument.defaultView;
+      var click = new window.Event('click');
+      button.dispatchEvent(click);
+    };
+    beforeEach((done) => {
+
+      sandbox = sinon.createSandbox();
+      putCall = sandbox.stub(axios, 'put').withArgs('/api/v1/requests/NR 2000952', sinon.match.any).returns(
+        new Promise((resolve) => resolve({
+          data:
+            {
+              additionalInfo: "More info",
+              applicants:
+                {
+                  addrLine1: "940 Blanshard Street",
+                  addrLine2: null,
+                  addrLine3: null,
+                  city: "Victoria",
+                  clientFirstName: null,
+                  clientLastName: null,
+                  contact: "John Test",
+                  countryTypeCd: "CA",
+                  declineNotificationInd: null,
+                  emailAddress: "testoutputs@gov.bc.ca",
+                  faxNumber: null,
+                  firstName: "John",
+                  lastName: "Test",
+                  middleName: null,
+                  partyId: 1822,
+                  phoneNumber: "2505555555",
+                  postalCd: "V8V4K8",
+                  stateProvinceCd: "BC"
+                },
+              comments: [],
+              consentFlag: null,
+              corpNum: null,
+              expirationDate: null,
+              furnished: "N",
+              id: 1822,
+              lastUpdate: "Thu, 18 Oct 2018 22:46:54 GMT",
+              names: [
+                {
+                  choice: 1,
+                  comment: null,
+                  conflict1: "",
+                  conflict1_num: "",
+                  conflict2: "",
+                  conflict2_num: "",
+                  conflict3: "",
+                  conflict3_num: "",
+                  consumptionDate: null,
+                  decision_text: "",
+                  name: "COLDSTREAM REFRIGERATION  HVAC SERVICES LIMITED",
+                  state: "REJECTED"
+                }],
+              natureBusinessInfo: "Nature of business can be pretty long so this one is more realistic. It even contains " +
+                "spaces and punctuation.",
+              nrNum: "NR 2000952",
+              nwpta: [],
+              previousNr: null,
+              previousRequestId: null,
+              previousStateCd: null,
+              priorityCd: "Y",
+              requestTypeCd: "CR",
+              state: "REJECTED",
+              submitCount: 1,
+              submittedDate: "Wed, 17 Oct 2018 11:37:20 GMT",
+              submitter_userid: "",
+              userId: "tester",
+              xproJurisdiction: null
+            }
+          }))
+      );
+      getCall = sandbox.stub(axios, 'get').withArgs('/api/v1/requests/NR 2000952', sinon.match.any).returns(
+        new Promise((resolve) => resolve({
+          data:
+            {
+              additionalInfo: "More info",
+              applicants:
+                {
+                  addrLine1: "940 Blanshard Street",
+                  addrLine2: null,
+                  addrLine3: null,
+                  city: "Victoria",
+                  clientFirstName: null,
+                  clientLastName: null,
+                  contact: "John Test",
+                  countryTypeCd: "CA",
+                  declineNotificationInd: null,
+                  emailAddress: "testoutputs@gov.bc.ca",
+                  faxNumber: null,
+                  firstName: "John",
+                  lastName: "Test",
+                  middleName: null,
+                  partyId: 1822,
+                  phoneNumber: "2505555555",
+                  postalCd: "V8V4K8",
+                  stateProvinceCd: "BC"
+                },
+              comments: [],
+              consentFlag: null,
+              corpNum: null,
+              expirationDate: null,
+              furnished: "N",
+              id: 1822,
+              lastUpdate: "Thu, 18 Oct 2018 22:46:54 GMT",
+              names: [
+                {
+                  choice: 1,
+                  comment: null,
+                  conflict1: "",
+                  conflict1_num: "",
+                  conflict2: "",
+                  conflict2_num: "",
+                  conflict3: "",
+                  conflict3_num: "",
+                  consumptionDate: null,
+                  decision_text: "",
+                  name: "COLDSTREAM REFRIGERATION  HVAC SERVICES LIMITED",
+                  state: "REJECTED"
+                }],
+              natureBusinessInfo: "Nature of business can be pretty long so this one is more realistic. It even contains " +
+                "spaces and punctuation.",
+              nrNum: "NR 2000952",
+              nwpta: [],
+              previousNr: null,
+              previousRequestId: null,
+              previousStateCd: null,
+              priorityCd: "Y",
+              requestTypeCd: "CR",
+              state: "REJECTED",
+              submitCount: 1,
+              submittedDate: "Wed, 17 Oct 2018 11:37:20 GMT",
+              submitter_userid: "",
+              userId: "tester",
+              xproJurisdiction: null
+            }
+          }))
+      );
+      patchCall = sandbox.stub(axios, 'patch').withArgs('/api/v1/requests/NR 2000952', sinon.match.any).returns(
+        new Promise((resolve) => resolve({
+          data:
+            {
+              message: "Request:NR 2000952 - patched"
+            }
+          }))
+      );
+      vm = instance.$mount();
+      vm.$store.commit('setLoginValues');
+      vm.$store.commit('nrNumber','NR 2000952');
+      setTimeout(()=>{
+        done();
+      }, 100)
+    });
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    describe('cancel/save testing', () => {
+      beforeEach((done) => {
+        click('#nr-details-edit-button');
+        setTimeout(()=>{
+          done();
+        }, 100)
+      });
+      afterEach((done) => {
+        setTimeout(()=> {
+          done();
+        }, 100)
+      });
+
+      it('has the cancel button working properly', () => {
+        console.log('CANCEL')
+        click('#nr-details-cancel-button');
+        setTimeout(()=> {
+          expect(vm.$el.querySelector('#nr-details-edit-button').textContent).toEqual('Edit');
+          expect(vm.$el.querySelector('#nr-details-save-button')).toBeNull();
+          expect(vm.$el.querySelector('#nr-details-cancel-button')).toBeNull();
+
+          // the PATCH should not have been called (ie: no change in state), just a GET
+          expect(patchCall.lastCall).toBeNull();
+          expect(getCall.lastCall).not.toBeNull();
+
+          console.log('END cancel')
+        }, 10);
+      });
+
+      it('has the save button working properly', () => {
+        console.log('START save')
+
+        expect(vm.validate()).toBeTruthy();
+        expect(vm.$el.querySelector('#nr-details-save-button').textContent).toEqual('Save');
+        click('#nr-details-save-button');
+
+        setTimeout(() => {
+          expect(vm.$el.querySelector('#nr-details-edit-button').textContent).toEqual('Edit');
+          expect(vm.$el.querySelector('#nr-details-save-button')).toBeNull();
+          expect(vm.$el.querySelector('#nr-details-cancel-button')).toBeNull();
+
+          // the PUT is called without changing the state, ie: it's still REJECTED
+          expect(putCall.lastCall).not.toBeNull();
+          expect(putCall.lastCall.args[1].state).toEqual('REJECTED');
+          expect(putCall.lastCall.args[1].previousStateCd).toEqual(null);
+
+          console.log('finished');
+        });
+      });
+    });
+
+  });
+
 });


### PR DESCRIPTION
*Issue #:* bcgov/name-examination#30

*Description of changes:*
Preserve DRAFT state upon edit (ie: don't lose place in queue). Requires corresponding API changes to function.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
