### PR TITLE
UI changes for conflicts list.

### DIFF
--- a/client/src/components/application/Examine/Recipe/conflicts/ConflictList.vue
+++ b/client/src/components/application/Examine/Recipe/conflicts/ConflictList.vue
@@ -155,11 +155,17 @@
   }
 
   /* when selected, highlight synonym matches in blue */
-  .conflict-list-view option.conflict-result:checked {
+  #conflict-list option.conflict-result:checked {
+    background: #b3d9ff linear-gradient(0deg, #b3d9ff 0%, #b3d9ff 100%);
+  }
+  #conflict-list:focus option.conflict-result:checked {
     background: #3979bd linear-gradient(0deg, #3979bd 0%, #3979bd 100%);
   }
   /* when selected, highlight exact match in red */
-  .conflict-list-view option.conflict-exact-match:checked {
+  #conflict-list option.conflict-exact-match:checked {
+    background: #ff9999 linear-gradient(0deg, #ff9999 0%, #ff9999 100%);
+  }
+  #conflict-list:focus option.conflict-exact-match:checked {
     background: red linear-gradient(0deg, red 0%, red 100%);
   }
 

--- a/client/src/components/application/Examine/Recipe/conflicts/ConflictList.vue
+++ b/client/src/components/application/Examine/Recipe/conflicts/ConflictList.vue
@@ -5,8 +5,10 @@
       <div class="row conflict-list-view">
         <select id="conflict-list" v-if="conflictData.length > 0"  v-model="selectedConflict" class="form-control" size="17" border="0"
                 @click="check_deselect" tabindex="2">
-          <option v-for="(option, index) in conflictData" :key="option.value"
-            v-bind:value="{nrNumber: option.nrNumber, text: option.text, source: option.source, index: index}">
+          <option v-for="(option, index) in conflictData" :key="option.value" :class="option.class"
+            v-bind:value="{nrNumber: option.nrNumber, text: option.text, source: option.source, index: index}"
+            v-bind:disabled="!option.source"
+          >
             {{ option.text }}
           </option>
 
@@ -30,16 +32,28 @@
     },
     computed: {
       conflictData() {
-        var data = [{ text:'< no exact match >' }];
+
+        var data = [];
+
+        // add Exact Match header
+        data = data.concat([{ text: 'Exact Match', class: 'exact-match-title'}]);
+
+        // add Exact Match data
         if (this.$store.getters.exactMatchesConflicts && this.$store.getters.exactMatchesConflicts.length > 0) {
-          data = this.$store.getters.exactMatchesConflicts;
+          data = data.concat(this.$store.getters.exactMatchesConflicts);
         }
-        data = data.concat([{ text:'***' }]);
+        else {
+          data = data.concat([{ text:'No Exact Match', class: 'conflict-no-match' }]);
+        }
+
+        // add Synonym Match header
+        data = data.concat([{ text: 'Exact Word Order + Synonym Match', class: 'synonym-match-title'}]);
+
+        // add Synonym Match data
         if (this.$store.getters.synonymMatchesConflicts && this.$store.getters.synonymMatchesConflicts.length)
           data = data.concat(this.$store.getters.synonymMatchesConflicts);
         else
-          data = data.concat([{ text:'< no synonym match >' }]);
-        data = data.concat([{ text:'***' }]);
+          data = data.concat([{ text:'No Match', class: 'conflict-no-match' }]);
         return data;
       },
     },
@@ -57,13 +71,16 @@
           this.$store.dispatch('getConflictInfo', this.selectedConflict);
       },
       setSelectedConflict() {
-        if (this.$store.getters.currentConflict == null && this.conflictData && this.conflictData.length > 0)
+        if (this.$store.getters.currentConflict == null && this.conflictData &&
+          this.conflictData.length > 1 && this.conflictData[1].source
+        ) {
           this.selectedConflict = {
-              index:0,
-              text:this.conflictData[0].text,
-              source:this.conflictData[0].source,
-              nrNumber:this.conflictData[0].nrNumber
+              index:1,
+              text:this.conflictData[1].text,
+              source:this.conflictData[1].source,
+              nrNumber:this.conflictData[1].nrNumber
           }
+        }
         else if (this.$store.getters.currentConflict != null)
           this.selectedConflict = this.$store.getters.currentConflict;
       }
@@ -101,8 +118,49 @@
     height: 100%;
   }
 
-  .conflict-list-view option {
+  .exact-match-title, .synonym-match-title {
+    background-color: #dedede;
+    font-weight: bold;
+    padding: 8px 5px;
+    color: black;
+  }
+  .synonym-match-title {
+    margin-top: 10px;
+  }
+
+  .conflict-synonym-title {
     padding: 5px;
+    margin-top: 5px;
+    text-transform: uppercase;
+    font-weight: bold;
+    color: black;
+  }
+
+  .conflict-result, .conflict-no-match {
+    padding: 5px;
+    padding-left: 40px;
+  }
+
+  .conflict-no-match {
+    color: #CCC;
+  }
+
+  .conflict-result {
+    color: #3979bd;
+  }
+
+  .conflict-exact-match {
+    color: red;
+    font-weight: bold;
+  }
+
+  /* when selected, highlight synonym matches in blue */
+  .conflict-list-view option.conflict-result:checked {
+    background: #3979bd linear-gradient(0deg, #3979bd 0%, #3979bd 100%);
+  }
+  /* when selected, highlight exact match in red */
+  .conflict-list-view option.conflict-exact-match:checked {
+    background: red linear-gradient(0deg, red 0%, red 100%);
   }
 
   h3, h2 {

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -783,7 +783,8 @@ export default new Vuex.Store({
         state.exactMatchesConflicts.push({
           text:entry.name,
           nrNumber:entry.id,
-          source:entry.source
+          source:entry.source,
+          class: 'conflict-result conflict-exact-match',
         })
       }
     },
@@ -791,13 +792,39 @@ export default new Vuex.Store({
     setSynonymMatchesConflicts(state, json) {
       state.synonymMatchesConflicts = [];
       let names = json.names;
+      var additionalRow = null;
+
       for (let i=0; i<names.length; i++) {
         let entry = names[i];
+        additionalRow = null;
+
+        // is this a synonym header? if so adjust and add class
+        if (entry.source == null) {
+          entry.name = entry.name.replace('----', '');
+          entry.name = entry.name.replace('synonyms:', '');
+          entry.class = 'conflict-synonym-title';
+
+          // if the next element is not a match, add a no results record
+          if (names[i+1].source == null) {
+            additionalRow = {
+              text: 'No Match',
+              source: null,
+              class: 'conflict-no-match',
+            }
+          }
+        }
+        else {
+          entry.class = 'conflict-result';
+        }
+
         state.synonymMatchesConflicts.push({
           text:entry.name,
           nrNumber:entry.id,
-          source:entry.source
-        })
+          source:entry.source,
+          class: entry.class,
+        });
+
+        if (additionalRow) state.synonymMatchesConflicts.push(additionalRow);
       }
     },
 

--- a/client/test/jest/ComponentSnapshotTests/application/examine/Recipe/conflicts/__snapshots__/ConflictList.spec.js.snap
+++ b/client/test/jest/ComponentSnapshotTests/application/examine/Recipe/conflicts/__snapshots__/ConflictList.spec.js.snap
@@ -15,31 +15,39 @@ exports[`ConflictList.vue renders a ConflictList component 1`] = `
       tabindex="2"
     >
       <option
+        class="exact-match-title"
+        disabled="disabled"
         value="[object Object]"
       >
         
-        &lt; no exact match &gt;
+        Exact Match
       
       </option>
       <option
+        class="conflict-no-match"
+        disabled="disabled"
         value="[object Object]"
       >
         
-        ***
+        No Exact Match
       
       </option>
       <option
+        class="synonym-match-title"
+        disabled="disabled"
         value="[object Object]"
       >
         
-        &lt; no synonym match &gt;
+        Exact Word Order + Synonym Match
       
       </option>
       <option
+        class="conflict-no-match"
+        disabled="disabled"
         value="[object Object]"
       >
         
-        ***
+        No Match
       
       </option>
     </select>

--- a/client/test/unit/specs/ExactMatchConflicts.spec.js
+++ b/client/test/unit/specs/ExactMatchConflicts.spec.js
@@ -86,13 +86,12 @@ describe('Exact-Match Conflicts', () => {
             expect(data.vm.$el.querySelector('#conflict-list').textContent).toContain('Incredible Name LTD')
         })
 
-        it('displays exact-match conflicts first', ()=>{
-            expect(data.vm.$el.querySelector('#conflict-list option:nth-child(1)').textContent.trim()).toEqual('Incredible Name LTD')
-            expect(data.vm.$el.querySelector('#conflict-list option:nth-child(2)').textContent.trim()).toEqual('***')
+        it('displays exact-match conflicts first (after title)', ()=>{
+            expect(data.vm.$el.querySelector('#conflict-list option:nth-child(2)').textContent.trim()).toEqual('Incredible Name LTD')
         })
 
         it('populates additional attributes as expected', ()=>{
-            expect(data.instance.$store.state.exactMatchesConflicts).toEqual([{ text:'Incredible Name LTD', nrNumber:'42', source:'moon' }])
+            expect(data.instance.$store.state.exactMatchesConflicts).toEqual([{ class: "conflict-result conflict-exact-match", text:'Incredible Name LTD', nrNumber:'42', source:'moon' }])
         })
 
         it('resists no exact match', (done)=>{
@@ -109,8 +108,7 @@ describe('Exact-Match Conflicts', () => {
                 sessionStorage.setItem('AUTHORIZED', true)
                 router.push('/nameExamination')
                 setTimeout(()=>{
-                    expect(data.vm.$el.querySelector('#conflict-list option:nth-child(1)').textContent.trim()).toEqual('< no exact match >')
-                    expect(data.vm.$el.querySelector('#conflict-list option:nth-child(2)').textContent.trim()).toEqual('***')
+                    expect(data.vm.$el.querySelector('#conflict-list option:nth-child(2)').textContent.trim()).toEqual('No Exact Match')
                     done();
                 }, 1000)
             }, 1000)

--- a/client/test/unit/specs/SynonymMatchConflicts.spec.js
+++ b/client/test/unit/specs/SynonymMatchConflicts.spec.js
@@ -87,19 +87,23 @@ describe('Synonym-Match Conflicts', () => {
         })
 
         it('displays synonym-match conflicts after exact match list', ()=>{
-            expect(data.vm.$el.querySelector('#conflict-list option:nth-child(2)').textContent.trim()).toEqual('***')
-            expect(data.vm.$el.querySelector('#conflict-list option:nth-child(3)').textContent.trim()).toEqual('----INCREDIBLE NAME INC*');
-            expect(data.vm.$el.querySelector('#conflict-list option:nth-child(4)').textContent.trim()).toEqual('----INCREDIBLE NAME*');
-            expect(data.vm.$el.querySelector('#conflict-list option:nth-child(5)').textContent.trim()).toEqual('----INCREDIBLE*');
-            expect(data.vm.$el.querySelector('#conflict-list option:nth-child(6)').textContent.trim()).toEqual('INCREDIBLE STEPS RECORDS, INC.');
+            expect(data.vm.$el.querySelector('#conflict-list option:nth-child(3)').textContent.trim()).toContain('Synonym Match')
+            expect(data.vm.$el.querySelector('#conflict-list option:nth-child(4)').textContent.trim()).toEqual('INCREDIBLE NAME INC*');
+            expect(data.vm.$el.querySelector('#conflict-list option:nth-child(5)').textContent.trim()).toEqual('No Match');
+            expect(data.vm.$el.querySelector('#conflict-list option:nth-child(6)').textContent.trim()).toEqual('INCREDIBLE NAME*');
+            expect(data.vm.$el.querySelector('#conflict-list option:nth-child(7)').textContent.trim()).toEqual('No Match');
+            expect(data.vm.$el.querySelector('#conflict-list option:nth-child(8)').textContent.trim()).toEqual('INCREDIBLE*');
+            expect(data.vm.$el.querySelector('#conflict-list option:nth-child(9)').textContent.trim()).toEqual('INCREDIBLE STEPS RECORDS, INC.');
         })
 
         it('populates additional attributes as expected', ()=>{
-            expect(data.instance.$store.state.synonymMatchesConflicts).toEqual([{"nrNumber": undefined,
-                "source": undefined, "text": "----INCREDIBLE NAME INC*"},
-                {"nrNumber": undefined, "source": undefined, "text": "----INCREDIBLE NAME*"},
-                {"nrNumber": undefined, "source": undefined, "text": "----INCREDIBLE*"},
-                {"nrNumber": "0793638", "source": "CORP", "text": "INCREDIBLE STEPS RECORDS, INC."}])
+            expect(data.instance.$store.state.synonymMatchesConflicts).toEqual([
+                {"class": "conflict-synonym-title", "nrNumber": undefined, "source": undefined, "text": "INCREDIBLE NAME INC*"},
+                {"class": "conflict-no-match", "source": null, "text": "No Match"},
+                {"class": "conflict-synonym-title", "nrNumber": undefined, "source": undefined, "text": "INCREDIBLE NAME*"},
+                {"class": "conflict-no-match", "source": null, "text": "No Match"},
+                {"class": "conflict-synonym-title", "nrNumber": undefined, "source": undefined, "text": "INCREDIBLE*"},
+                {"class": "conflict-result", "nrNumber": "0793638", "source": "CORP", "text": "INCREDIBLE STEPS RECORDS, INC."}])
         })
 
         it('resists no synonym match', (done)=>{
@@ -116,8 +120,7 @@ describe('Synonym-Match Conflicts', () => {
                 sessionStorage.setItem('AUTHORIZED', true)
                 router.push('/nameExamination')
                 setTimeout(()=>{
-                    expect(data.vm.$el.querySelector('#conflict-list option:nth-child(3)').textContent.trim()).toEqual('< no synonym match >')
-                    expect(data.vm.$el.querySelector('#conflict-list option:nth-child(4)').textContent.trim()).toEqual('***')
+                    expect(data.vm.$el.querySelector('#conflict-list option:nth-child(4)').textContent.trim()).toEqual('No Match')
                     done();
                 }, 1000)
             }, 1000)


### PR DESCRIPTION
*Issue #:* bcgov/entity#46

*Description of changes:*
UI changes to conflicts list. No rework of underlying structure (still a select element) with changes to style as far as they can go, but not as far as the desired UI would like.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
