### PR TITLE
Handle money symbols

### DIFF
--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -1324,6 +1324,10 @@ export default new Vuex.Store({
           .replace(/\[/g, '')
           .replace(/}/g, '')
           .replace(/{/g, '')
+          .replace(/(^| )(\$+(\s|$)+)+/g, '$1DOLLAR$3')
+          .replace(/(^| )(¢+(\s|$)+)+/g, '$1CENT$3')
+          .replace(/\$/g, 'S')
+          .replace(/¢/g,'C')
       const myToken = sessionStorage.getItem('KEYCLOAK_TOKEN')
       query = query.substring(0, 1) == '+' ? query.substring(1) : query;
       query = encodeURIComponent(query)
@@ -1355,6 +1359,10 @@ export default new Vuex.Store({
           .replace(/\?/g,'')
           .replace(/#/g,'')
           .replace(/%/g, '')
+          .replace(/(^| )(\$+(\s|$)+)+/g, '$1DOLLAR$3')
+          .replace(/(^| )(¢+(\s|$)+)+/g, '$1CENT$3')
+          .replace(/\$/g, 'S')
+          .replace(/¢/g,'C')
       const myToken = sessionStorage.getItem('KEYCLOAK_TOKEN');
       const url = '/api/v1/requests/synonymbucket/' + query;
       console.log('URL:' + url);

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -792,7 +792,7 @@ export default new Vuex.Store({
     setSynonymMatchesConflicts(state, json) {
       state.synonymMatchesConflicts = [];
       let names = json.names;
-      var additionalRow = null;
+      let additionalRow = null;
 
       for (let i=0; i<names.length; i++) {
         let entry = names[i];

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -1324,10 +1324,10 @@ export default new Vuex.Store({
           .replace(/\[/g, '')
           .replace(/}/g, '')
           .replace(/{/g, '')
-          .replace(/(^|\s+)(\$+(\s|$)+)+/g, '$1dollar$3')
-          .replace(/(^|\s+)(¢+(\s|$)+)+/g, '$1cent$3')
-          .replace(/\$/g, 's')
-          .replace(/¢/g, 'c')
+          .replace(/(^|\s+)(\$+(\s|$)+)+/g, '$1DOLLAR$3')
+          .replace(/(^|\s+)(¢+(\s|$)+)+/g, '$1CENT$3')
+          .replace(/\$/g, 'S')
+          .replace(/¢/g, 'C')
       const myToken = sessionStorage.getItem('KEYCLOAK_TOKEN')
       query = query.substring(0, 1) == '+' ? query.substring(1) : query;
       query = encodeURIComponent(query)
@@ -1359,10 +1359,10 @@ export default new Vuex.Store({
           .replace(/\?/g,'')
           .replace(/#/g,'')
           .replace(/%/g, '')
-          .replace(/(^| )(\$+(\s|$)+)+/g, '$1dollar$3')
-          .replace(/(^| )(¢+(\s|$)+)+/g, '$1cent$3')
-          .replace(/\$/g, 's')
-          .replace(/¢/g,'c')
+          .replace(/(^| )(\$+(\s|$)+)+/g, '$1DOLLAR$3')
+          .replace(/(^| )(¢+(\s|$)+)+/g, '$1CENT$3')
+          .replace(/\$/g, 'S')
+          .replace(/¢/g,'C')
       const myToken = sessionStorage.getItem('KEYCLOAK_TOKEN');
       const url = '/api/v1/requests/synonymbucket/' + query;
       console.log('URL:' + url);

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -1317,7 +1317,6 @@ export default new Vuex.Store({
     checkManualExactMatches( {commit, state}, query ) {
 
       console.log('action: getting exact matches for number: ' + state.compInfo.nrNumber + ' from solr')
-      console.log('query: ********', query)
       query = query.replace(' \/','\/')
           .replace(/\(/g, '')
           .replace(/\)/g, '')
@@ -1326,8 +1325,7 @@ export default new Vuex.Store({
           .replace(/}/g, '')
           .replace(/{/g, '')
           .replace(/(^|\s+)(\$+(\s|$)+)+/g, '$1dollar$3')
-        console.log('query2 ******', query)
-          query = query.replace(/(^|\s+)(¢+(\s|$)+)+/g, '$1cent$3')
+          .replace(/(^|\s+)(¢+(\s|$)+)+/g, '$1cent$3')
           .replace(/\$/g, 's')
           .replace(/¢/g, 'c')
       const myToken = sessionStorage.getItem('KEYCLOAK_TOKEN')

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -1317,6 +1317,7 @@ export default new Vuex.Store({
     checkManualExactMatches( {commit, state}, query ) {
 
       console.log('action: getting exact matches for number: ' + state.compInfo.nrNumber + ' from solr')
+      console.log('query: ********', query)
       query = query.replace(' \/','\/')
           .replace(/\(/g, '')
           .replace(/\)/g, '')
@@ -1324,10 +1325,11 @@ export default new Vuex.Store({
           .replace(/\[/g, '')
           .replace(/}/g, '')
           .replace(/{/g, '')
-          .replace(/(^| )(\$+(\s|$)+)+/g, '$1DOLLAR$3')
-          .replace(/(^| )(¢+(\s|$)+)+/g, '$1CENT$3')
-          .replace(/\$/g, 'S')
-          .replace(/¢/g,'C')
+          .replace(/(^|\s+)(\$+(\s|$)+)+/g, '$1dollar$3')
+        console.log('query2 ******', query)
+          query = query.replace(/(^|\s+)(¢+(\s|$)+)+/g, '$1cent$3')
+          .replace(/\$/g, 's')
+          .replace(/¢/g, 'c')
       const myToken = sessionStorage.getItem('KEYCLOAK_TOKEN')
       query = query.substring(0, 1) == '+' ? query.substring(1) : query;
       query = encodeURIComponent(query)
@@ -1359,10 +1361,10 @@ export default new Vuex.Store({
           .replace(/\?/g,'')
           .replace(/#/g,'')
           .replace(/%/g, '')
-          .replace(/(^| )(\$+(\s|$)+)+/g, '$1DOLLAR$3')
-          .replace(/(^| )(¢+(\s|$)+)+/g, '$1CENT$3')
-          .replace(/\$/g, 'S')
-          .replace(/¢/g,'C')
+          .replace(/(^| )(\$+(\s|$)+)+/g, '$1dollar$3')
+          .replace(/(^| )(¢+(\s|$)+)+/g, '$1cent$3')
+          .replace(/\$/g, 's')
+          .replace(/¢/g,'c')
       const myToken = sessionStorage.getItem('KEYCLOAK_TOKEN');
       const url = '/api/v1/requests/synonymbucket/' + query;
       console.log('URL:' + url);

--- a/client/test/unit/specs/ExactMatchesRequest.spec.js
+++ b/client/test/unit/specs/ExactMatchesRequest.spec.js
@@ -33,4 +33,10 @@ describe('store > checkManualExactMatches', () => {
         expect(exactMatch.lastCall.args[0]).toEqual('/api/v1/exact-match?query=dog%26cat')
     })
 
+    it('changes the money symbols', ()=>{
+        store.dispatch('checkManualExactMatches', 'my $ $tore ¢ a¢¢ept ')
+
+        expect(exactMatch.lastCall.args[0]).toEqual('/api/v1/exact-match?query=my%20dollar%20store%20cent%20accept%20')
+    })
+
 })

--- a/client/test/unit/specs/ExactMatchesRequest.spec.js
+++ b/client/test/unit/specs/ExactMatchesRequest.spec.js
@@ -36,7 +36,7 @@ describe('store > checkManualExactMatches', () => {
     it('changes the money symbols', ()=>{
         store.dispatch('checkManualExactMatches', 'my $ $tore ¢ a¢¢ept ')
 
-        expect(exactMatch.lastCall.args[0]).toEqual('/api/v1/exact-match?query=my%20dollar%20store%20cent%20accept%20')
+        expect(exactMatch.lastCall.args[0]).toEqual('/api/v1/exact-match?query=my%20DOLLAR%20Store%20CENT%20aCCept%20')
     })
 
 })

--- a/client/test/unit/specs/SynonymMatchesRequest.spec.js
+++ b/client/test/unit/specs/SynonymMatchesRequest.spec.js
@@ -47,6 +47,12 @@ describe('store > checkManualSynonymMatches', () => {
         expect(SynonymMatch.lastCall.args[0]).toEqual('/api/v1/requests/synonymbucket/dog cat  fish   bear')
     })
 
+    it('replaces $ and ¢ with a dollar and cent, or s and c', ()=>{
+        store.dispatch('checkManualSynonymMatches', 'big $ $tore ¢ a¢¢eptable ')
+
+        expect(SynonymMatch.lastCall.args[0]).toEqual('/api/v1/requests/synonymbucket/big dollar store cent acceptable ')
+    })
+
     it('removes brackets', ()=>{
         store.dispatch('checkManualSynonymMatches', 'dog (cat) {fish} [bear]')
 

--- a/client/test/unit/specs/SynonymMatchesRequest.spec.js
+++ b/client/test/unit/specs/SynonymMatchesRequest.spec.js
@@ -50,7 +50,7 @@ describe('store > checkManualSynonymMatches', () => {
     it('replaces $ and ¢ with a dollar and cent, or s and c', ()=>{
         store.dispatch('checkManualSynonymMatches', 'big $ $tore ¢ a¢¢eptable ')
 
-        expect(SynonymMatch.lastCall.args[0]).toEqual('/api/v1/requests/synonymbucket/big dollar store cent acceptable ')
+        expect(SynonymMatch.lastCall.args[0]).toEqual('/api/v1/requests/synonymbucket/big DOLLAR Store CENT aCCeptable ')
     })
 
     it('removes brackets', ()=>{


### PR DESCRIPTION
*Issue #:bcgov/entity#67*

*Description of changes:*

- Update the urls sent to the solr query to use dollar or s for $ and cent or c for ¢, to match the indexed names.
- Update the tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
