### PR TITLE
collapse last 2

### DIFF
--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -820,6 +820,7 @@ export default new Vuex.Store({
       }
 	  var count = 0
 	  var stopCollapsing = false
+	  var collapseCount = 2
 	  for (let i=state.synonymMatchesConflicts.length-1; i>=0; i--){
 		  let entry = state.synonymMatchesConflicts[i]
 		  if (! stopCollapsing) {
@@ -830,7 +831,10 @@ export default new Vuex.Store({
 			  if (entry.class == 'conflict-synonym-title') {
 				  entry.count = count
 				  count = 0
-				  stopCollapsing = true
+				  collapseCount --
+				  if (collapseCount == 0) {
+					  stopCollapsing = true
+				  }
 				  if (entry.count > 0) {
 				  	entry.class = 'conflict-synonym-title collapsible collapsed'
 				  }

--- a/client/test/unit/specs/SynonymMatchesData.spec.js
+++ b/client/test/unit/specs/SynonymMatchesData.spec.js
@@ -19,18 +19,24 @@ describe('store > setSynonymMatchesConflicts', () => {
 				{ name:'second title' },
 				{ name:'second match #1', source:'CORP' },
 				{ name:'second match #2', source:'CORP' },
+				{ name:'third title' },
+				{ name:'third match #1', source:'CORP' },
+				{ name:'third match #2', source:'CORP' },
 			] })
 			data = store.state.synonymMatchesConflicts
 		})
 
-		it('identifies titles and collape the last one', ()=>{
+		it('identifies titles and collape the two last', ()=>{
 			expect(data[0].class).toEqual('conflict-synonym-title collapsible expanded')
 			expect(data[2].class).toEqual('conflict-synonym-title collapsible collapsed')
+			expect(data[5].class).toEqual('conflict-synonym-title collapsible collapsed')
 		})
-		it('identifies matches and hides the last set', ()=>{
+		it('identifies matches and hides the last two sets', ()=>{
 			expect(data[1].class).toEqual('conflict-result conflict-result-displayed')
 			expect(data[3].class).toEqual('conflict-result conflict-result-hidden')
 			expect(data[4].class).toEqual('conflict-result conflict-result-hidden')
+			expect(data[6].class).toEqual('conflict-result conflict-result-hidden')
+			expect(data[7].class).toEqual('conflict-result conflict-result-hidden')
 		})
 		it('includes count', ()=>{
 			expect(data[2].count).toEqual(2)

--- a/client/test/unit/specs/SynonymMatchesDisplay.spec.js
+++ b/client/test/unit/specs/SynonymMatchesDisplay.spec.js
@@ -17,6 +17,9 @@ describe('ConflictList.vue synonym matches expand/collapse', () => {
 			{ name:'second title - meta2' },
 			{ name:'second match #1', source:'CORP' },
 			{ name:'second match #2', source:'CORP' },
+			{ name:'third title - meta3' },
+			{ name:'third match #1', source:'CORP' },
+			{ name:'third match #2', source:'CORP' },
 		] })
 		data = vm.$store.getters.synonymMatchesConflicts
 	})


### PR DESCRIPTION
*Description of changes:*
we now collapse the last two stacks in the synonym bucket


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
