### PR TITLE
Issue #86 block non names users

### DIFF
--- a/client/src/components/auth/Signin.vue
+++ b/client/src/components/auth/Signin.vue
@@ -12,9 +12,14 @@
           userName: ''
         }
     },
+
     mounted() {
-      var authorized = sessionStorage.getItem("AUTHORIZED");
-      var keycloak
+      let authorized = sessionStorage.getItem("AUTHORIZED");
+      let keycloak;
+      const EXAMINER = 'names_approver';
+      const STAFF = 'names_editor';
+      const VIEWER = 'names_viewer';
+      const ALLOWED_ROLES = [EXAMINER, STAFF, VIEWER]
 
       if (!authorized) {
         //keycloak = Keycloak('static/keycloak/sbcKey.json');
@@ -23,6 +28,7 @@
 
         var token
         const vm = this
+        console.log("MOUNTED THIS", this)
 
         keycloak.init({token: token, onLoad: 'login-required'}).success(function (authenticated) {
           if (authenticated) {
@@ -30,28 +36,31 @@
 
             sessionStorage.setItem('KEYCLOAK_TOKEN', keycloak.token);
             sessionStorage.setItem('KEYCLOAK_REFRESH', keycloak.refreshToken);
-            localStorage.setItem('KEYCLOAK_EXPIRES', keycloak.tokenParsed.exp * 1000);
-            localStorage.setItem('USER_ROLE',keycloak.tokenParsed.user_role)
-            if(keycloak.tokenParsed.user_role == undefined){
+            sessionStorage.setItem('KEYCLOAK_EXPIRES', keycloak.tokenParsed.exp * 1000);
+            let roles = keycloak.realmAccess.roles.filter(role => ALLOWED_ROLES.includes(role));
+            sessionStorage.setItem('USER_ROLES', roles);
+
+            if(!roles || roles.length === 0) {
+              console.log('********** DANGER, WILL ROBINSON, DANGER! logging out... because user has a token but no ROLE!')
               sessionStorage.setItem("AUTHORIZED", false);
-            }else {
+            } else {
+              console.log('Authorized role(s) for user!');
               sessionStorage.setItem("AUTHORIZED", true);
-            }
-            //TODO-erase this once rolls creaated
-            sessionStorage.setItem("AUTHORIZED", true);
+
 
             // Get user profile
             keycloak.loadUserProfile().success(function (userProfile) {
               app.userName = userProfile.username;
-              localStorage.setItem('USERNAME', app.userName);
+              sessionStorage.setItem('USERNAME', app.userName);
 
-              console.log('set logion values in store')
+              console.log('set login values');
               vm.$store.commit('setLoginValues')
 
-            });
+              });
 
-            // everthing is good, re-direct to home page
-            vm.$router.push("/home")
+              // everthing is good, re-direct to home page
+              vm.$router.push("/home")
+            }
 
           } else {
             alert('not authenticated');

--- a/client/src/components/auth/Signin.vue
+++ b/client/src/components/auth/Signin.vue
@@ -28,7 +28,6 @@
 
         var token
         const vm = this
-        console.log("MOUNTED THIS", this)
 
         keycloak.init({token: token, onLoad: 'login-required'}).success(function (authenticated) {
           if (authenticated) {
@@ -46,7 +45,6 @@
             } else {
               console.log('Authorized role(s) for user!');
               sessionStorage.setItem("AUTHORIZED", true);
-
 
             // Get user profile
             keycloak.loadUserProfile().success(function (userProfile) {

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -13,7 +13,7 @@ export default new Vuex.Store({
 
     myKeycloak: null,
     userId: null,
-    user_role: null,
+    user_roles: null,
     authorized: false,
     email: null,
     errorJSON: null,
@@ -203,7 +203,6 @@ export default new Vuex.Store({
       state.compInfo.requestType = value;
     },
     is_my_current_nr (state, value) {
-      console.log('got to mutation with value ' + value);
       state.is_my_current_nr = value;
     },
     is_making_decision(state, value) {
@@ -875,8 +874,8 @@ export default new Vuex.Store({
     },
 
     setLoginValues(state){
-      state.userId=localStorage.getItem('USERNAME')
-      state.user_role=localStorage.getItem('USER_ROLE')
+      state.userId=sessionStorage.getItem('USERNAME')
+      state.user_roles=sessionStorage.getItem('USER_ROLES')
       state.authorized=sessionStorage.getItem('AUTHORIZED')
     },
 
@@ -893,9 +892,9 @@ export default new Vuex.Store({
       sessionStorage.removeItem('KEYCLOAK_REFRESH')
       sessionStorage.removeItem('KEYCLOAK_TOKEN')
       sessionStorage.removeItem('AUTHORIZED')
-      localStorage.removeItem('KEYCLOAK_EXPIRES')
-      localStorage.removeItem('USERNAME')
-      localStorage.removeItem('USER_ROLE')
+      sessionStorage.removeItem('KEYCLOAK_EXPIRES')
+      sessionStorage.removeItem('USERNAME')
+      sessionStorage.removeItem('USER_ROLES')
 
     },
 
@@ -920,9 +919,9 @@ export default new Vuex.Store({
     tryAutoLogin ({commit}) {
     },
 
-    checkToken({dispatch, state}){
+    checkToken({dispatch, state}) {
       // checks if keycloak object exists - if not then state is unstable, force logout
-      if(state.myKeycloak==null){
+      if (state.myKeycloak==null) {
         console.log('myKeycloak is null')
         //TODO - reset everything and force login???
         //should only be null when first logging on (async keycloak)- if it becomes null somehow should we force another login?
@@ -937,11 +936,11 @@ export default new Vuex.Store({
 
       console.log('Token expires in ' + expiresIn + 'seconds, updating')
 
-      if(expiresIn < 1700 && expiresIn > 0) {
+      if (expiresIn < 1700 && expiresIn > 0) {
         console.log('Updating Token')
         dispatch('updateToken')
 
-      }else if(expiresIn < 0) {
+      } else if(expiresIn < 0) {
         //TODO - reset everything and force login???
         console.log('Force Logout')
         dispatch('logout')
@@ -950,13 +949,13 @@ export default new Vuex.Store({
       }
     },
 
-    updateToken({commit, state}){
+    updateToken({commit, state}) {
       const vm = this;
       state.myKeycloak.updateToken(-1).success(function (refreshed) {
         if (refreshed) {
           sessionStorage.setItem('KEYCLOAK_TOKEN', state.myKeycloak.token);
           sessionStorage.setItem('KEYCLOAK_REFRESH', state.myKeycloak.refreshToken);
-          localStorage.setItem('KEYCLOAK_EXPIRES', state.myKeycloak.tokenParsed.exp * 1000);
+          sessionStorage.setItem('KEYCLOAK_EXPIRES', state.myKeycloak.tokenParsed.exp * 1000);
         } else {
           console.log('Token is still valid, not refreshed');
         }

--- a/client/test/features/specs/support/clean.state.js
+++ b/client/test/features/specs/support/clean.state.js
@@ -6,7 +6,7 @@ module.exports = {
 
       myKeycloak: {},
       userId: null,
-      user_role: null,
+      user_roles: null,
       authorized: false,
       email: null,
       errorJSON: null,

--- a/client/test/unit/specs/RequestInfoHeader.spec.js
+++ b/client/test/unit/specs/RequestInfoHeader.spec.js
@@ -13,9 +13,9 @@ describe('RequestInfoHeader.vue', () => {
   let instance;
 
   beforeEach(() => {
-    localStorage.setItem('USERNAME', 'tester');
-    localStorage.setItem('USER_ROLE', 'test');
-    localStorage.setItem('AUTHORIZED', 'true');
+    sessionStorage.setItem('USERNAME', 'tester');
+    sessionStorage.setItem('USER_ROLES', 'test');
+    sessionStorage.setItem('AUTHORIZED', 'true');
     const Constructor = Vue.extend(RequestInfoHeader);
     instance = new Constructor({store: store});
     instance.$store.state.myKeycloak = {}


### PR DESCRIPTION
*Issue #:* bcgov/entity#86

*Description of changes:*

- Retrieve the roles from keycloak when authenticating user in front end.
- Make sure they don't get permission to access anything when they aren't a **names_\*** user

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
