### PR TITLE
Escape specail characters when send the request to solr

### DIFF
--- a/client/src/components/auth/Signin.vue
+++ b/client/src/components/auth/Signin.vue
@@ -12,9 +12,14 @@
           userName: ''
         }
     },
+
     mounted() {
-      var authorized = sessionStorage.getItem("AUTHORIZED");
-      var keycloak
+      let authorized = sessionStorage.getItem("AUTHORIZED");
+      let keycloak;
+      const EXAMINER = 'names_approver';
+      const STAFF = 'names_editor';
+      const VIEWER = 'names_viewer';
+      const ALLOWED_ROLES = [EXAMINER, STAFF, VIEWER]
 
       if (!authorized) {
         //keycloak = Keycloak('static/keycloak/sbcKey.json');
@@ -30,28 +35,30 @@
 
             sessionStorage.setItem('KEYCLOAK_TOKEN', keycloak.token);
             sessionStorage.setItem('KEYCLOAK_REFRESH', keycloak.refreshToken);
-            localStorage.setItem('KEYCLOAK_EXPIRES', keycloak.tokenParsed.exp * 1000);
-            localStorage.setItem('USER_ROLE',keycloak.tokenParsed.user_role)
-            if(keycloak.tokenParsed.user_role == undefined){
+            sessionStorage.setItem('KEYCLOAK_EXPIRES', keycloak.tokenParsed.exp * 1000);
+            let roles = keycloak.realmAccess.roles.filter(role => ALLOWED_ROLES.includes(role));
+            sessionStorage.setItem('USER_ROLES', roles);
+
+            if(!roles || roles.length === 0) {
+              console.log('********** DANGER, WILL ROBINSON, DANGER! logging out... because user has a token but no ROLE!')
               sessionStorage.setItem("AUTHORIZED", false);
-            }else {
+            } else {
+              console.log('Authorized role(s) for user!');
               sessionStorage.setItem("AUTHORIZED", true);
-            }
-            //TODO-erase this once rolls creaated
-            sessionStorage.setItem("AUTHORIZED", true);
 
             // Get user profile
-            keycloak.loadUserProfile().success(function (userProfile) {
-              app.userName = userProfile.username;
-              localStorage.setItem('USERNAME', app.userName);
+              keycloak.loadUserProfile().success(function (userProfile) {
+                app.userName = userProfile.username;
+                sessionStorage.setItem('USERNAME', app.userName);
 
-              console.log('set logion values in store')
-              vm.$store.commit('setLoginValues')
+                console.log('set login values');
+                vm.$store.commit('setLoginValues')
 
-            });
+              });
 
-            // everthing is good, re-direct to home page
-            vm.$router.push("/home")
+              // everthing is good, re-direct to home page
+              vm.$router.push("/home")
+            }
 
           } else {
             alert('not authenticated');

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -1477,16 +1477,13 @@ export default new Vuex.Store({
 
       console.log('action: getting exact matches for number: ' + state.compInfo.nrNumber + ' from solr')
       query = query.replace(' \/','\/')
-          .replace(/\(/g, '')
-          .replace(/\)/g, '')
-          .replace(/]/g, '')
-          .replace(/\[/g, '')
-          .replace(/}/g, '')
-          .replace(/{/g, '')
           .replace(/(^|\s+)(\$+(\s|$)+)+/g, '$1DOLLAR$3')
           .replace(/(^|\s+)(¢+(\s|$)+)+/g, '$1CENT$3')
           .replace(/\$/g, 'S')
           .replace(/¢/g, 'C')
+          .replace(/\\/g, '')
+          .replace(/\//g, '')
+          .replace(/(`|~|!|\||\(|\)|\[|\]|\{|\}|:|"|\^|#|%|\?)/g, '')
       const myToken = sessionStorage.getItem('KEYCLOAK_TOKEN')
       query = query.substring(0, 1) == '+' ? query.substring(1) : query;
       query = encodeURIComponent(query)
@@ -1505,23 +1502,15 @@ export default new Vuex.Store({
 
       console.log('action: getting synonym matches for number: ' + state.compInfo.nrNumber + ' from solr')
       query = query.replace(/\//g,' ')
-          .replace(/\\/g,' ')
-          .replace(/&/g, ' ')
-          .replace(/\+/g, ' ')
-          .replace(/\-/g, ' ')
-          .replace(/\(/g, '')
-          .replace(/\)/g, '')
-          .replace(/}/g, '')
-          .replace(/{/g, '')
-          .replace(/]/g, '')
-          .replace(/\[/g, '')
-          .replace(/\?/g,'')
-          .replace(/#/g,'')
-          .replace(/%/g, '')
-          .replace(/(^| )(\$+(\s|$)+)+/g, '$1DOLLAR$3')
-          .replace(/(^| )(¢+(\s|$)+)+/g, '$1CENT$3')
-          .replace(/\$/g, 'S')
-          .replace(/¢/g,'C')
+                .replace(/\\/g,' ')
+                .replace(/&/g, ' ')
+                .replace(/\+/g, ' ')
+                .replace(/\-/g, ' ')
+                .replace(/(^| )(\$+(\s|$)+)+/g, '$1DOLLAR$3')
+                .replace(/(^| )(¢+(\s|$)+)+/g, '$1CENT$3')
+                .replace(/\$/g, 'S')
+                .replace(/¢/g,'C')
+                .replace(/(`|~|!|\||\(|\)|\[|\]|\{|\}|:|"|\^|#|%|\?)/g, '')
       const myToken = sessionStorage.getItem('KEYCLOAK_TOKEN');
       const url = '/api/v1/requests/synonymbucket/' + query;
       console.log('URL:' + url);
@@ -1541,20 +1530,11 @@ export default new Vuex.Store({
           .replace(/&/g, ' ')
           .replace(/\+/g, ' ')
           .replace(/\-/g, ' ')
-          .replace(/\(/g, '')
-          .replace(/\)/g, '')
-          .replace(/}/g, '')
-          .replace(/{/g, '')
-          .replace(/]/g, '')
-          .replace(/\[/g, '')
-          .replace(/\?/g,'')
-          .replace(/#/g,'')
-          .replace(/%/g, '')
           .replace(/(^| )(\$+(\s|$)+)+/g, '$1DOLLAR$3')
           .replace(/(^| )(¢+(\s|$)+)+/g, '$1CENT$3')
           .replace(/\$/g, 'S')
           .replace(/¢/g,'C')
-
+          .replace(/(`|~|!|\||\(|\)|\[|\]|\{|\}|:|"|\^|#|%|\?)/g, '')
       const myToken = sessionStorage.getItem('KEYCLOAK_TOKEN');
       const url = '/api/v1/requests/cobrsphonetics/' + query;
       console.log('URL:' + url);
@@ -1574,20 +1554,11 @@ export default new Vuex.Store({
           .replace(/&/g, ' ')
           .replace(/\+/g, ' ')
           .replace(/\-/g, ' ')
-          .replace(/\(/g, '')
-          .replace(/\)/g, '')
-          .replace(/}/g, '')
-          .replace(/{/g, '')
-          .replace(/]/g, '')
-          .replace(/\[/g, '')
-          .replace(/\?/g,'')
-          .replace(/#/g,'')
-          .replace(/%/g, '')
           .replace(/(^| )(\$+(\s|$)+)+/g, '$1DOLLAR$3')
           .replace(/(^| )(¢+(\s|$)+)+/g, '$1CENT$3')
           .replace(/\$/g, 'S')
           .replace(/¢/g,'C')
-
+          .replace(/(`|~|!|\||\(|\)|\[|\]|\{|\}|:|"|\^|#|%|\?)/g, '')
       const myToken = sessionStorage.getItem('KEYCLOAK_TOKEN');
       const url = '/api/v1/requests/phonetics/' + query;
       console.log('URL:' + url);
@@ -1635,6 +1606,16 @@ export default new Vuex.Store({
       const myHeader =  {headers: {Authorization: `Bearer ${myToken}`}};
       const url = '/api/v1/documents:histories'
       console.log('URL:' + url)
+      searchStr = searchStr.replace(/\//g,' ')
+          .replace(/\\/g,' ')
+          .replace(/&/g, ' ')
+          .replace(/\+/g, ' ')
+          .replace(/\-/g, ' ')
+          .replace(/(^| )(\$+(\s|$)+)+/g, '$1DOLLAR$3')
+          .replace(/(^| )(¢+(\s|$)+)+/g, '$1CENT$3')
+          .replace(/\$/g, 'S')
+          .replace(/¢/g,'C')
+          .replace(/(`|~|!|\||\(|\)|\[|\]|\{|\}|:|"|\^|#|%|\?)/g, '')
       const vm = this
       return axios.post(url, {type: 'plain_text', content: searchStr }, myHeader).then(response => {
         console.log('Check Manual Histories Response:' + response.data)
@@ -1649,6 +1630,25 @@ export default new Vuex.Store({
       const myHeader =  {headers: {Authorization: `Bearer ${myToken}`}};
       const url = '/api/v1/documents:trademarks'
       console.log('URL:' + url)
+      searchStr = searchStr.replace(/\//g,' ')
+          .replace(/\\/g,' ')
+          .replace(/&/g, ' ')
+          .replace(/\+/g, ' ')
+          .replace(/\-/g, ' ')
+          .replace(/\(/g, '')
+          .replace(/\)/g, '')
+          .replace(/}/g, '')
+          .replace(/{/g, '')
+          .replace(/]/g, '')
+          .replace(/\[/g, '')
+          .replace(/\?/g,'')
+          .replace(/#/g,'')
+          .replace(/%/g, '')
+          .replace(/(^| )(\$+(\s|$)+)+/g, '$1DOLLAR$3')
+          .replace(/(^| )(¢+(\s|$)+)+/g, '$1CENT$3')
+          .replace(/\$/g, 'S')
+          .replace(/¢/g,'C')
+          .replace(/(`|~|!|\||\(|\)|\[|\]|\{|\}|:|"|\^|#|%|\?)/g, '')
       const vm = this
       return axios.post(url, {type: 'plain_text', content: searchStr }, myHeader).then(response => {
         console.log('Check Manual Trademarks Response:' + response.data)

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -13,7 +13,7 @@ export default new Vuex.Store({
 
     myKeycloak: null,
     userId: null,
-    user_role: null,
+    user_roles: null,
     authorized: false,
     email: null,
     errorJSON: null,
@@ -205,7 +205,6 @@ export default new Vuex.Store({
       state.compInfo.requestType = value;
     },
     is_my_current_nr (state, value) {
-      console.log('got to mutation with value ' + value);
       state.is_my_current_nr = value;
     },
     is_making_decision(state, value) {
@@ -1005,8 +1004,8 @@ export default new Vuex.Store({
     },
 
     setLoginValues(state){
-      state.userId=localStorage.getItem('USERNAME')
-      state.user_role=localStorage.getItem('USER_ROLE')
+      state.userId=sessionStorage.getItem('USERNAME')
+      state.user_roles=sessionStorage.getItem('USER_ROLES')
       state.authorized=sessionStorage.getItem('AUTHORIZED')
     },
 
@@ -1023,9 +1022,9 @@ export default new Vuex.Store({
       sessionStorage.removeItem('KEYCLOAK_REFRESH')
       sessionStorage.removeItem('KEYCLOAK_TOKEN')
       sessionStorage.removeItem('AUTHORIZED')
-      localStorage.removeItem('KEYCLOAK_EXPIRES')
-      localStorage.removeItem('USERNAME')
-      localStorage.removeItem('USER_ROLE')
+      sessionStorage.removeItem('KEYCLOAK_EXPIRES')
+      sessionStorage.removeItem('USERNAME')
+      sessionStorage.removeItem('USER_ROLES')
 
     },
 
@@ -1050,9 +1049,9 @@ export default new Vuex.Store({
     tryAutoLogin ({commit}) {
     },
 
-    checkToken({dispatch, state}){
+    checkToken({dispatch, state}) {
       // checks if keycloak object exists - if not then state is unstable, force logout
-      if(state.myKeycloak==null){
+      if (state.myKeycloak==null) {
         console.log('myKeycloak is null')
         //TODO - reset everything and force login???
         //should only be null when first logging on (async keycloak)- if it becomes null somehow should we force another login?
@@ -1067,11 +1066,11 @@ export default new Vuex.Store({
 
       console.log('Token expires in ' + expiresIn + 'seconds, updating')
 
-      if(expiresIn < 1700 && expiresIn > 0) {
+      if (expiresIn < 1700 && expiresIn > 0) {
         console.log('Updating Token')
         dispatch('updateToken')
 
-      }else if(expiresIn < 0) {
+      } else if(expiresIn < 0) {
         //TODO - reset everything and force login???
         console.log('Force Logout')
         dispatch('logout')
@@ -1080,13 +1079,13 @@ export default new Vuex.Store({
       }
     },
 
-    updateToken({commit, state}){
+    updateToken({commit, state}) {
       const vm = this;
       state.myKeycloak.updateToken(-1).success(function (refreshed) {
         if (refreshed) {
           sessionStorage.setItem('KEYCLOAK_TOKEN', state.myKeycloak.token);
           sessionStorage.setItem('KEYCLOAK_REFRESH', state.myKeycloak.refreshToken);
-          localStorage.setItem('KEYCLOAK_EXPIRES', state.myKeycloak.tokenParsed.exp * 1000);
+          sessionStorage.setItem('KEYCLOAK_EXPIRES', state.myKeycloak.tokenParsed.exp * 1000);
         } else {
           console.log('Token is still valid, not refreshed');
         }

--- a/client/test/features/specs/support/clean.state.js
+++ b/client/test/features/specs/support/clean.state.js
@@ -6,7 +6,7 @@ module.exports = {
 
       myKeycloak: {},
       userId: null,
-      user_role: null,
+      user_roles: null,
       authorized: false,
       email: null,
       errorJSON: null,

--- a/client/test/unit/specs/CobrsPhoneticMatchesRequest.spec.js
+++ b/client/test/unit/specs/CobrsPhoneticMatchesRequest.spec.js
@@ -77,8 +77,8 @@ describe('store > checkManualCobrsPhoneticMatches', () => {
         expect(CobrsPhonetic.lastCall.args[0]).toEqual('/api/v1/requests/cobrsphonetics/dog  cat fish bear')
     })
 
-      it('escape special characters', ()=>{
-        store.dispatch('checkManualPhoneticMatches', '/?.><\\\'\":;\\|][}{=+_-)(*&^%$#@!~`ATHENAE/?.><\\\'\":;\\|][}{=+_-)(*&^%$#@!~`UM 139 LTD./?.><\\\'":;\\|][}{=+_-)(*&^%$#@!~`')
+    it('escape special characters', ()=>{
+        store.dispatch('checkManualCobrsPhoneticMatches', '/?.><\\\'\":;\\|][}{=+_-)(*&^%$#@!~`ATHENAE/?.><\\\'\":;\\|][}{=+_-)(*&^%$#@!~`UM 139 LTD./?.><\\\'":;\\|][}{=+_-)(*&^%$#@!~`')
 
         expect(CobrsPhonetic.lastCall.args[0]).toEqual('/api/v1/requests/cobrsphonetics/ .>< \'; = _ * S@ATHENAE .>< \'; = _ * S@UM 139 LTD. .>< \'; = _ * S@')
     })

--- a/client/test/unit/specs/CobrsPhoneticMatchesRequest.spec.js
+++ b/client/test/unit/specs/CobrsPhoneticMatchesRequest.spec.js
@@ -77,5 +77,9 @@ describe('store > checkManualCobrsPhoneticMatches', () => {
         expect(CobrsPhonetic.lastCall.args[0]).toEqual('/api/v1/requests/cobrsphonetics/dog  cat fish bear')
     })
 
+      it('escape special characters', ()=>{
+        store.dispatch('checkManualPhoneticMatches', '/?.><\\\'\":;\\|][}{=+_-)(*&^%$#@!~`ATHENAE/?.><\\\'\":;\\|][}{=+_-)(*&^%$#@!~`UM 139 LTD./?.><\\\'":;\\|][}{=+_-)(*&^%$#@!~`')
 
+        expect(CobrsPhonetic.lastCall.args[0]).toEqual('/api/v1/requests/cobrsphonetics/ .>< \'; = _ * S@ATHENAE .>< \'; = _ * S@UM 139 LTD. .>< \'; = _ * S@')
+    })
 })

--- a/client/test/unit/specs/ExactMatchesRequest.spec.js
+++ b/client/test/unit/specs/ExactMatchesRequest.spec.js
@@ -39,4 +39,9 @@ describe('store > checkManualExactMatches', () => {
         expect(exactMatch.lastCall.args[0]).toEqual('/api/v1/exact-match?query=my%20DOLLAR%20Store%20CENT%20aCCept%20')
     })
 
+    it('escape special characters', ()=>{
+        store.dispatch('checkManualExactMatches', '/?.><\\\'\":;\\|][}{=+_-)(*&^%$#@!~`ATHENAE/?.><\\\'\":;\\|][}{=+_-)(*&^%$#@!~`UM 139 LTD./?.><\\\'":;\\|][}{=+_-)(*&^%$#@!~`')
+
+        expect(exactMatch.lastCall.args[0]).toEqual('/api/v1/exact-match?query=.%3E%3C\'%3B%3D%2B_-*%26S%40ATHENAE.%3E%3C\'%3B%3D%2B_-*%26S%40UM%20139%20LTD..%3E%3C\'%3B%3D%2B_-*%26S%40')
+    })
 })

--- a/client/test/unit/specs/PhoneticMatchesRequest.spec.js
+++ b/client/test/unit/specs/PhoneticMatchesRequest.spec.js
@@ -77,5 +77,9 @@ describe('store > checkManualPhoneticMatches', () => {
         expect(CobrsPhonetic.lastCall.args[0]).toEqual('/api/v1/requests/phonetics/dog  cat fish bear')
     })
 
+    it('escape special characters', ()=>{
+        store.dispatch('checkManualPhoneticMatches', '/?.><\\\'\":;\\|][}{=+_-)(*&^%$#@!~`ATHENAE/?.><\\\'\":;\\|][}{=+_-)(*&^%$#@!~`UM 139 LTD./?.><\\\'":;\\|][}{=+_-)(*&^%$#@!~`')
 
+        expect(CobrsPhonetic.lastCall.args[0]).toEqual('/api/v1/requests/phonetics/ .>< \'; = _ * S@ATHENAE .>< \'; = _ * S@UM 139 LTD. .>< \'; = _ * S@')
+    })
 })

--- a/client/test/unit/specs/RequestInfoHeader.spec.js
+++ b/client/test/unit/specs/RequestInfoHeader.spec.js
@@ -13,9 +13,9 @@ describe('RequestInfoHeader.vue', () => {
   let instance;
 
   beforeEach(() => {
-    localStorage.setItem('USERNAME', 'tester');
-    localStorage.setItem('USER_ROLE', 'test');
-    localStorage.setItem('AUTHORIZED', 'true');
+    sessionStorage.setItem('USERNAME', 'tester');
+    sessionStorage.setItem('USER_ROLES', 'test');
+    sessionStorage.setItem('AUTHORIZED', 'true');
     const Constructor = Vue.extend(RequestInfoHeader);
     instance = new Constructor({store: store});
     instance.$store.state.myKeycloak = {}

--- a/client/test/unit/specs/SynonymMatchesRequest.spec.js
+++ b/client/test/unit/specs/SynonymMatchesRequest.spec.js
@@ -77,5 +77,9 @@ describe('store > checkManualSynonymMatches', () => {
         expect(SynonymMatch.lastCall.args[0]).toEqual('/api/v1/requests/synonymbucket/dog  cat fish bear')
     })
 
+    it('escape special characters', ()=>{
+        store.dispatch('checkManualSynonymMatches', '/?.><\\\'\":;\\|][}{=+_-)(*&^%$#@!~`ATHENAE/?.><\\\'\":;\\|][}{=+_-)(*&^%$#@!~`UM 139 LTD./?.><\\\'":;\\|][}{=+_-)(*&^%$#@!~`')
 
+        expect(SynonymMatch.lastCall.args[0]).toEqual('/api/v1/requests/synonymbucket/ .>< \'; = _ * S@ATHENAE .>< \'; = _ * S@UM 139 LTD. .>< \'; = _ * S@')
+    })
 })


### PR DESCRIPTION
Signed-off-by: PWEI <patrick.wei@gov.bc.ca>

*Issue #:*If a manual search with the following character, a 500 error is displayed on the screen.

- start with a slash
- colon
- end with a back slash
- unbalanced double quotes
- unbalanced single quotes
- contain @
- contain other special characters

*Description of changes:*
Add a regex check to escape the special characters before sending the request to solr searches.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
