### PR TITLE
Upon reset, set NR status to Draft instead of INPROGRESS.

### DIFF
--- a/client/src/components/application/Examine/CompName.vue
+++ b/client/src/components/application/Examine/CompName.vue
@@ -411,15 +411,15 @@
         this.$store.commit('currentCondition', null);
       },
       reOpen() {
-        // set current state to INPROGRESS
-        this.$store.commit('currentState', 'INPROGRESS');
+        // set current state to DRAFT
+        this.$store.commit('currentState', 'DRAFT');
 
         // update request in database
         this.$store.dispatch('updateRequest');
       },
       reset() {
-        // set current state to INPROGRESS and clear furnished flag
-        this.$store.commit('currentState', 'INPROGRESS');
+        // set current state to DRAFT and clear furnished flag
+        this.$store.commit('currentState', 'DRAFT');
         this.$store.commit('furnished', 'N');
 
         // update request in database

--- a/client/test/unit/specs/CompName.spec.js
+++ b/client/test/unit/specs/CompName.spec.js
@@ -566,7 +566,7 @@ describe('CompName.vue', () => {
           click('#examine-reset-button');
 
           setTimeout(() => {
-            expect(instance.$store.state.currentState).toEqual("INPROGRESS");
+            expect(instance.$store.state.currentState).toEqual("DRAFT");
           }, 10)
         });
 
@@ -599,7 +599,7 @@ describe('CompName.vue', () => {
           click('#examine-re-open-button');
 
           setTimeout(() => {
-            expect(instance.$store.state.currentState).toEqual("INPROGRESS");
+            expect(instance.$store.state.currentState).toEqual("DRAFT");
           }, 10)
         });
 


### PR DESCRIPTION
*Issue #:* bcgov/entity#40

*Description of changes:*
Upon reset, set NR status to Draft instead of INPROGRESS.
This mainly affects re-open, as reset is forced in API call.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
