### PR TITLE
Upon re-open, handle data in API in the same way as Reset, so that de…

### DIFF
--- a/client/src/components/application/Examine/CompName.vue
+++ b/client/src/components/application/Examine/CompName.vue
@@ -413,6 +413,7 @@
       reOpen() {
         // set current state to DRAFT
         this.$store.commit('currentState', 'DRAFT');
+        this.$store.commit('hasBeenReset', true);
 
         // update request in database
         this.$store.dispatch('updateRequest');

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -41,6 +41,7 @@ export default new Vuex.Store({
     acceptance_will_be_conditional: false,
     is_header_shown: false,
     furnished: null,
+    hasBeenReset: null,
     listPriorities: null, // DROP LIST
     listJurisdictions: null, // DROP LIST
     listRequestTypes: null, // DROP LIST
@@ -354,6 +355,9 @@ export default new Vuex.Store({
     furnished(state,value) {
       state.furnished = value;
     },
+    hasBeenReset(state,value) {
+      state.hasBeenReset = value;
+    },
     clearAuthData (state) {
       state.userId = null
       state.authorized = null
@@ -540,6 +544,7 @@ export default new Vuex.Store({
       state.previousNr = dbcompanyInfo.previousNr
       state.corpNum = dbcompanyInfo.corpNum
       state.furnished = dbcompanyInfo.furnished
+      state.hasBeenReset = dbcompanyInfo.hasBeenReset
 
       console.log('Setting nwpta data in state variables')
       // cycle through nwpta entries
@@ -693,6 +698,7 @@ export default new Vuex.Store({
       state.nrData.previousNr = state.previousNr
       state.nrData.corpNum = state.corpNum
       state.nrData.furnished = state.furnished
+      state.nrData.hasBeenReset = state.hasBeenReset
     },
 
     loadCompanyIssues(state, dbcompanyIssues) {
@@ -1699,6 +1705,9 @@ export default new Vuex.Store({
     },
     furnished(state) {
       return state.furnished;
+    },
+    hasBeenReset(state) {
+      return state.hasBeenReset;
     },
     is_complete(state) {
       // indicates a complete NR


### PR DESCRIPTION
*Issue #:* bcgov/entity:#110

*Description of changes:*
Upon re-open, handle data in API in the same way as Reset, so that decision data is maintained in Namex and cleared in NRO. This is done by manually setting hasBeenReset flag in Re-Open PUT.

Corresponding API changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
