### PR TITLE
Hide Examine button from editor users

### DIFF
--- a/client/src/components/application/Examine/CompName.vue
+++ b/client/src/components/application/Examine/CompName.vue
@@ -245,7 +245,7 @@
       can_claim() {
         console.log('got to can_claim with status ' + this.currentState);
         // can this user claim the NR? Based on state.
-        if (this.userCanExamine && ['DRAFT', 'HOLD'].indexOf(this.currentState) > -1) return true;
+        if (this.userIsAnExaminer && ['DRAFT', 'HOLD'].indexOf(this.currentState) > -1) return true;
         else return false;
       },
       compName1() {

--- a/client/src/components/application/Examine/CompName.vue
+++ b/client/src/components/application/Examine/CompName.vue
@@ -245,7 +245,7 @@
       can_claim() {
         console.log('got to can_claim with status ' + this.currentState);
         // can this user claim the NR? Based on state.
-        if (this.userCanEdit && ['DRAFT', 'HOLD'].indexOf(this.currentState) > -1) return true;
+        if (this.userCanExamine && ['DRAFT', 'HOLD'].indexOf(this.currentState) > -1) return true;
         else return false;
       },
       compName1() {

--- a/client/test/unit/specs/CompName.spec.js
+++ b/client/test/unit/specs/CompName.spec.js
@@ -484,6 +484,44 @@ describe('CompName.vue', () => {
       });
    })
 
+   describe('Editors cannot see the examine button for a draft NR', () => {
+      let sandbox;
+      let vm;
+
+      beforeEach((done) => {
+        instance.$store.state.currentState = 'DRAFT';
+        instance.$store.state.furnished = 'N';
+        instance.$store.state.compInfo.compNames = {
+          compName1:
+            {
+              choice: 1,
+              name: "Bad Name",
+              state: 'REJECTED'
+            },
+          compName2: { choice: 2, name: "They Named a Language after ME", state: 'NE' },
+          compName3: { choice: 3, name: null, state: 'NE' }
+        };
+        vm = instance.$mount();
+        sessionStorage.setItem('USER_ROLES', ['names_editor']);
+        sessionStorage.setItem('USERNAME', 'Ada');
+        vm.$store.commit('setLoginValues');
+
+        sandbox = sinon.createSandbox();
+        setTimeout(() => {
+          done();
+        }, 100)
+      });
+
+      afterEach(() => {
+        sandbox.restore()
+      });
+
+      it('Hides the examine button for staff/editor', () => {
+         expect(vm.$el.querySelector('#examine-button')).toBeNull()
+      });
+   })
+
+
     describe('Reset & Re-Open', ()=> {
       let vm;
 


### PR DESCRIPTION
*Issue #:*
bcgov/entity#116

*Description of changes:*
Hide the Examine button from all users except examiners.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
