### PR TITLE
Hide Examine Names link for editors

### DIFF
--- a/client/src/components/application/sections/StdHeader.vue
+++ b/client/src/components/application/sections/StdHeader.vue
@@ -45,8 +45,8 @@
           <li class="nav-item">
             <a target="_blank" href="https://namex-solr-dev.pathfinder.gov.bc.ca" id="admin" class="nav-link">Admin</a>
           </li>
-          <li v-if="userCanEdit" class="navbar-text divider">|</li>
-          <li v-if="userCanEdit" class="nav-item">
+          <li v-if="userCanExamine" class="navbar-text divider">|</li>
+          <li v-if="userCanExamine" class="nav-item">
             <router-link to="/nameExamination" id="nameExamine" class="nav-link">Examine Names</router-link>
           </li>
           <li class="navbar-text divider">|</li>
@@ -87,8 +87,8 @@
       auth() {
         return this.$store.getters.isAuthenticated
       },
-      userCanEdit() {
-        return this.$store.getters.userHasEditRole
+      userCanExamine() {
+        return this.$store.getters.userHasApproverRole
       }
     },
     methods: {

--- a/client/test/unit/specs/StdHeader.spec.js
+++ b/client/test/unit/specs/StdHeader.spec.js
@@ -86,6 +86,34 @@ describe('StdHeader.vue', () => {
         })
     })
 
+    describe('Navigation menu when logged in as editor or viewer', ()=> {
+
+      it('does not offer a link to /nameExamination for editors', ()=>{
+        store = {
+          getters: {
+            isAuthenticated: true,
+            userHasApproverRole: false,
+            userHasEditRole: true
+          },
+        }
+        vm = mount();
+      console.log(vm.$el.querySelector('#nameExamine'))
+          expect(vm.$el.querySelector('#nameExamine')).toEqual(null);
+      })
+      it('does not offer a link to /nameExamination for viewers', ()=>{
+        store = {
+          getters: {
+            isAuthenticated: true,
+            userHasApproverRole: false,
+            userHasEditRole: false
+          },
+        }
+        vm = mount();
+        console.log(vm.$el.querySelector('#nameExamine'))
+          expect(vm.$el.querySelector('#nameExamine')).toEqual(null);
+      })
+    })
+
     describe('Navigation menu when not logged in', ()=>{
 
         beforeEach(() => {


### PR DESCRIPTION
*Issue #:*
bcgov/entity#122
*Description of changes:*
Hide the examine names link in the header for everyone but examiners

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
