### PR TITLE
Removed main page-blocking spinner from recipe steps, and replaced with call-specific spinner in various sections of recipe/exam page.

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -15,7 +15,7 @@
   <link rel="stylesheet" href="static/css/bootstrap.min.css">
 
   <!-- STANDARD CSS -->
-  <link type="text/css" href="static/css/main.css" rel="stylesheet"/>
+  <link type="text/css" href="static/css/main.css?20190131" rel="stylesheet"/>
 
   <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
   <link rel="stylesheet" href="static/css/ie10-viewport-bug-workaround.css"/>
@@ -27,11 +27,9 @@
 <body>
 <div id="loading-overlay">
   <div class="spinner">
-    <div class="rect1"></div>
-    <div class="rect2"></div>
-    <div class="rect3"></div>
-    <div class="rect4"></div>
-    <div class="rect5"></div>
+    <div class="bounce1"></div>
+    <div class="bounce2"></div>
+    <div class="bounce3"></div>
   </div>
 </div>
 <div id="app"></div>

--- a/client/src/components/application/Examine/Decision.vue
+++ b/client/src/components/application/Examine/Decision.vue
@@ -4,7 +4,7 @@
     <div class="row">
       <div class="col-6 add-top-padding">
         <h3>Conditions</h3>
-        <div>
+        <div id="decision-conditions-dropdown">
         <multiselect
           v-model="conditions_selected"
           :options="conditions_onlycustomerfacing"

--- a/client/src/components/application/Examine/Recipe/conditions/conditionInfo.vue
+++ b/client/src/components/application/Examine/Recipe/conditions/conditionInfo.vue
@@ -1,15 +1,23 @@
 /* eslint-disable */
 <template>
-  <span v-on:click="setSelection($event);">
-    <datatable v-bind="$data"/>
+  <span>
+    <spinner className="conditions-spinner hidden" />
+
+    <span id="conditions-wrapper" v-on:click="setSelection($event);">
+      <datatable v-bind="$data"/>
+    </span>
   </span>
 </template>
 
 <script>
 /* eslint-disable */
+  import spinner from '@/components/application/spinner.vue';
 
   export default {
     name: 'conditionInfo',
+    components: {
+      spinner,
+    },
     data: () => ({
       fixHeaderAndSetBodyMaxHeight: 300,
       tblStyle: 'table-layout: fixed',
@@ -155,6 +163,11 @@
     color: #c69500;
     width: 50px;
   }
+  /* hide the content when spinner is showing, ie: results are loading */
+  .spinner:not(.hidden) + #conditions-wrapper {
+    display: none;
+  }
+
 </style>
 
 <!-- unscoped style -->

--- a/client/src/components/application/Examine/Recipe/conflicts/ConflictInfo.vue
+++ b/client/src/components/application/Examine/Recipe/conflicts/ConflictInfo.vue
@@ -4,6 +4,8 @@
     <div class="container-fluid">
       <div class="row ConflictInfo">
 
+          <spinner className="conflict-detail-spinner hidden" />
+
           <div class="col conflict-info-view">
             <div v-if="is_corp" class="add-top-padding">
               <corpMatch />
@@ -28,10 +30,12 @@
 import nullMatch from '@/components/application/Examine/Recipe/conflicts/conflictInfoType/nullMatch.vue';
 import namesMatch from '@/components/application/Examine/Recipe/conflicts/conflictInfoType/namesMatch.vue';
 import corpMatch from '@/components/application/Examine/Recipe/conflicts/conflictInfoType/corpMatch.vue';
+import spinner from '@/components/application/spinner.vue';
 
   export default {
     name: 'ConflictInfo',
     components: {
+      spinner,
       namesMatch,
       corpMatch,
       nullMatch
@@ -67,7 +71,12 @@ import corpMatch from '@/components/application/Examine/Recipe/conflicts/conflic
     padding: 10px;
   }
 
-h3, h2 {
+  /* hide the panel content when spinner is showing, ie: results are loading */
+  .spinner:not(.hidden) + .conflict-info-view {
+    display: none;
+  }
+
+  h3, h2 {
     font-size: 15px;
   }
   p {

--- a/client/src/components/application/Examine/Recipe/conflicts/ConflictList.vue
+++ b/client/src/components/application/Examine/Recipe/conflicts/ConflictList.vue
@@ -5,7 +5,19 @@
       <div class="row conflict-list-view">
         <div id="conflict-list" v-if="conflictData.length > 0"  class="form-control" size="17" border="0"
                 tabindex="2" style="overflow-y: scroll; max-height:480px">
-          <div v-for="(option, index) in conflictData" :key="option.value" :class="option.class" @click="clic(option)">
+
+          <!-- EXACT MATCH -->
+          <div v-for="(option, index) in exactMatchData" :key="option.value" :class="option.class" @click="clic(option)">
+            <template v-if="option.class.indexOf('spinner') >= 0">
+              <spinner className="mini" />
+            </template>
+            <template v-else>
+              <div v-html="option.highlightedText"></div>
+            </template>
+          </div>
+
+          <!-- SYNONYMS -->
+          <div v-for="(option, index) in synonymMatchData" :key="option.value" :class="option.class" @click="clic(option)">
             <template v-if="option.class == 'conflict-synonym-title'">
               <div style="float:left; max-width:80%">
                 <span v-html="option.highlightedText" class="conflict-title"></span>
@@ -30,7 +42,17 @@
                 <i class="fa fa-chevron-up"/>
               </div>
             </template>
-            <template v-else-if="option.class == 'conflict-cobrs-phonetic-title'">
+            <template v-else-if="option.class.indexOf('spinner') >= 0">
+              <spinner className="mini" />
+            </template>
+            <template v-else>
+              <div v-html="option.highlightedText"></div>
+            </template>
+          </div>
+
+          <!-- COBRS PHONETIC -->
+          <div v-for="(option, index) in cobrsPhoneticData" :key="option.value" :class="option.class" @click="clic(option)">
+            <template v-if="option.class == 'conflict-cobrs-phonetic-title'">
               <div style="float:left; max-width:80%">
                 <span class="conflict-title">{{ option.text }}</span>
               </div>
@@ -52,7 +74,17 @@
                 <i class="fa fa-chevron-up"/>
               </div>
             </template>
-            <template v-else-if="option.class == 'conflict-phonetic-title'">
+            <template v-else-if="option.class.indexOf('spinner') >= 0">
+              <spinner className="mini" />
+            </template>
+            <template v-else>
+              <div v-html="option.highlightedText"></div>
+            </template>
+          </div>
+
+          <!-- PHONETIC (EXPERIMENTAL) -->
+          <div v-for="(option, index) in phoneticData" :key="option.value" :class="option.class" @click="clic(option)">
+            <template v-if="option.class == 'conflict-phonetic-title'">
               <div style="float:left; max-width:80%">
                 <span class="conflict-title">{{ option.text }}</span>
               </div>
@@ -74,12 +106,15 @@
                 <i class="fa fa-chevron-up"/>
               </div>
             </template>
+            <template v-else-if="option.class.indexOf('spinner') >= 0">
+              <spinner className="mini" />
+            </template>
             <template v-else>
               <div v-html="option.highlightedText"></div>
             </template>
-		      </div>
+          </div>
 
-	      </div>
+        </div>
         <div v-else class="empty-list">( No data )</div>
 
       </div>
@@ -90,22 +125,39 @@
 
 <script>
 /* eslint-disable */
+  import spinner from '@/components/application/spinner.vue';
+
   export default {
     name: 'ConflictList',
+    components: {
+      spinner,
+    },
     data: function () {
       return {
         selectedConflict: '',
-		conflictEntries: [],
-		selection: { class:'' }
+        conflictEntries: [],
+        selection: {class: ''}
       }
     },
     computed: {
       conflictData() {
 
         var data = [];
+        data = data.concat(this.exactMatchData);
+        data = data.concat(this.synonymMatchData);
+        data = data.concat(this.cobrsPhoneticData);
+        data = data.concat(this.phoneticData);
 
-        // add Exact Match header
+        this.conflictEntries = data;
+
+        return data;
+      },
+      exactMatchData() {
+        var data = [];
+
+        // add Exact Match header & spinner
         data = data.concat([{ highlightedText: 'Exact Match', class: 'exact-match-title'}]);
+        data = data.concat([{text: '', class: 'exact-match-spinner spinner-wrapper hidden'}]);
 
         // add Exact Match data
         if (this.$store.getters.exactMatchesConflicts && this.$store.getters.exactMatchesConflicts.length > 0) {
@@ -115,169 +167,196 @@
           data = data.concat([{ highlightedText:'No Exact Match', class: 'conflict-no-match' }]);
         }
 
-        // add Synonym Match header
+        return data;
+      },
+      synonymMatchData() {
+        var data = [];
+
+        // add Synonym Match header & spinner
         data = data.concat([{ highlightedText: 'Exact Word Order + Synonym Match', class: 'synonym-match-title'}]);
+        data = data.concat([{text: '', class: 'synonym-match-spinner spinner-wrapper hidden'}]);
 
         // add Synonym Match data
         if (this.$store.getters.synonymMatchesConflicts && this.$store.getters.synonymMatchesConflicts.length) {
           data = data.concat(this.$store.getters.synonymMatchesConflicts);
         }
-        // add cobrs phonetic match header
+        else {
+          data = data.concat([{ highlightedText:'No Match', class: 'conflict-no-match' }]);
+        }
+
+        return data;
+      },
+      cobrsPhoneticData() {
+        var data = [];
+
+        // add cobrs phonetic match header & spinner
         data = data.concat([{ highlightedText: 'Character Swap Match', class: 'cobrs-phonetic-match-title'}]);
+        data = data.concat([{text: '', class: 'cobrs-phonetic-match-spinner spinner-wrapper hidden'}]);
 
         // add cobrs phonetic data
-        if (this.$store.getters.cobrsPhoneticConflicts && this.$store.getters.cobrsPhoneticConflicts.length) {
+        if (this.$store.getters.cobrsPhoneticConflicts && this.$store.getters.cobrsPhoneticConflicts.length > 0) {
           data = data.concat(this.$store.getters.cobrsPhoneticConflicts);
-	  	  }
-        // add phonetic match header
+        }
+        else {
+          data = data.concat([{ highlightedText:'No Match', class: 'conflict-no-match' }]);
+        }
+
+        return data;
+      },
+      phoneticData() {
+        var data = [];
+
+        // add phonetic match header & spinner
         data = data.concat([{ highlightedText: 'Phonetic Match (experimental)', class: 'phonetic-match-title'}]);
+        data = data.concat([{text: '', class: 'phonetic-match-spinner spinner-wrapper hidden'}]);
 
         // add phonetic data
         if (this.$store.getters.phoneticConflicts && this.$store.getters.phoneticConflicts.length) {
           data = data.concat(this.$store.getters.phoneticConflicts);
-	  	  }
-        else
+        }
+        else {
           data = data.concat([{ highlightedText:'No Match', class: 'conflict-no-match' }]);
-
-		    this.conflictEntries = data
+        }
 
         return data;
       },
     },
     mounted() {
-		console.log('ConflictList mounted');
+      console.log('ConflictList mounted');
       this.selectedConflict = '';
       this.setSelectedConflict();
     },
     methods: {
-		clic(what) {
-			if (what.class.indexOf('conflict-synonym-title collapsible') == 0) {
-				this.expand_collapse(what, 'synonym')
-			}
-			if (what.class.indexOf('conflict-cobrs-phonetic-title collapsible') == 0) {
-				this.expand_collapse(what,'cobrsPhonetic')
-			}
-			if (what.class.indexOf('conflict-phonetic-title collapsible') == 0) {
-				this.expand_collapse(what,'phonetic')
-			}
-			if (what.class.indexOf('conflict-result') == 0) {
-				this.unselectPreviousSelection()
-				what.class += ' conflict-result-selected'
-				this.selection = what
-				this.selectedConflict = what
-				this.check_deselect()
-			}
-		},
-		unselectPreviousSelection() {
-			this.selection.class = this.selection.class.replace(' conflict-result-selected', '')
-			var entries = this.conflictEntries
-			for (let i=0; i<entries.length; i++){
-				let entry = entries[i]
-				if (entry.class.indexOf('conflict-result') != -1) {
-					entry.class = entry.class.replace(' conflict-result-selected', '')
-				}
-			}
-		},
-		expand_collapse(what, bucket) {
-			let toggleIt = false
-      if (bucket == 'synonym') {
-        for (let i = 0; i < this.$store.getters.synonymMatchesConflicts.length; i++) {
-          let entry = this.$store.getters.synonymMatchesConflicts[i]
-          if (entry.class.indexOf('conflict-synonym-title collapsible') == 0) {
-            if (entry.text == what.text) {
-              toggleIt = true
-              if (entry.class == 'conflict-synonym-title collapsible collapsed') {
-                entry.class = 'conflict-synonym-title collapsible expanded'
-              } else {
-                entry.class = 'conflict-synonym-title collapsible collapsed'
-              }
-            } else {
-              toggleIt = false
-            }
+      clic(what) {
+        if (what.class.indexOf('conflict-synonym-title collapsible') == 0) {
+          this.expand_collapse(what, 'synonym')
+        }
+        if (what.class.indexOf('conflict-cobrs-phonetic-title collapsible') == 0) {
+          this.expand_collapse(what, 'cobrsPhonetic')
+        }
+        if (what.class.indexOf('conflict-phonetic-title collapsible') == 0) {
+          this.expand_collapse(what, 'phonetic')
+        }
+        if (what.class.indexOf('conflict-result') == 0) {
+          this.unselectPreviousSelection()
+          what.class += ' conflict-result-selected'
+          this.selection = what
+          this.selectedConflict = what
+          this.check_deselect()
+        }
+      },
+      unselectPreviousSelection() {
+        this.selection.class = this.selection.class.replace(' conflict-result-selected', '')
+        var entries = this.conflictEntries
+        for (let i = 0; i < entries.length; i++) {
+          let entry = entries[i]
+          if (entry.class.indexOf('conflict-result') != -1) {
+            entry.class = entry.class.replace(' conflict-result-selected', '')
           }
-          if (entry.class.indexOf('conflict-result') != -1 && toggleIt) {
-            if (entry.class.indexOf('conflict-result-hidden') != -1) {
-              entry.class = entry.class.replace('conflict-result-hidden', 'conflict-result-displayed')
-            } else {
-              entry.class = entry.class.replace('conflict-result-displayed', 'conflict-result-hidden')
+        }
+      },
+      expand_collapse(what, bucket) {
+        let toggleIt = false
+        if (bucket == 'synonym') {
+          for (let i = 0; i < this.$store.getters.synonymMatchesConflicts.length; i++) {
+            let entry = this.$store.getters.synonymMatchesConflicts[i]
+            if (entry.class.indexOf('conflict-synonym-title collapsible') == 0) {
+              if (entry.text == what.text) {
+                toggleIt = true
+                if (entry.class == 'conflict-synonym-title collapsible collapsed') {
+                  entry.class = 'conflict-synonym-title collapsible expanded'
+                } else {
+                  entry.class = 'conflict-synonym-title collapsible collapsed'
+                }
+              } else {
+                toggleIt = false
+              }
+            }
+            if (entry.class.indexOf('conflict-result') != -1 && toggleIt) {
+              if (entry.class.indexOf('conflict-result-hidden') != -1) {
+                entry.class = entry.class.replace('conflict-result-hidden', 'conflict-result-displayed')
+              } else {
+                entry.class = entry.class.replace('conflict-result-displayed', 'conflict-result-hidden')
+              }
             }
           }
         }
-      }
-      if (bucket == 'cobrsPhonetic') {
-        for (let i = 0; i < this.$store.getters.cobrsPhoneticConflicts.length; i++) {
-          let entry = this.$store.getters.cobrsPhoneticConflicts[i]
-          if (entry.class.indexOf('conflict-cobrs-phonetic-title collapsible') == 0) {
-            if (entry.text == what.text) {
-              toggleIt = true
-              if (entry.class == 'conflict-cobrs-phonetic-title collapsible collapsed') {
-                entry.class = 'conflict-cobrs-phonetic-title collapsible expanded'
+        if (bucket == 'cobrsPhonetic') {
+          for (let i = 0; i < this.$store.getters.cobrsPhoneticConflicts.length; i++) {
+            let entry = this.$store.getters.cobrsPhoneticConflicts[i]
+            if (entry.class.indexOf('conflict-cobrs-phonetic-title collapsible') == 0) {
+              if (entry.text == what.text) {
+                toggleIt = true
+                if (entry.class == 'conflict-cobrs-phonetic-title collapsible collapsed') {
+                  entry.class = 'conflict-cobrs-phonetic-title collapsible expanded'
+                } else {
+                  entry.class = 'conflict-cobrs-phonetic-title collapsible collapsed'
+                }
               } else {
-                entry.class = 'conflict-cobrs-phonetic-title collapsible collapsed'
+                toggleIt = false
               }
-            } else {
-              toggleIt = false
             }
-          }
-          if (entry.class.indexOf('conflict-result') != -1 && toggleIt) {
-            if (entry.class.indexOf('conflict-result-hidden') != -1) {
-              entry.class = entry.class.replace('conflict-result-hidden', 'conflict-result-displayed')
-            } else {
-              entry.class = entry.class.replace('conflict-result-displayed', 'conflict-result-hidden')
+            if (entry.class.indexOf('conflict-result') != -1 && toggleIt) {
+              if (entry.class.indexOf('conflict-result-hidden') != -1) {
+                entry.class = entry.class.replace('conflict-result-hidden', 'conflict-result-displayed')
+              } else {
+                entry.class = entry.class.replace('conflict-result-displayed', 'conflict-result-hidden')
+              }
             }
           }
         }
-      }
-      if (bucket == 'phonetic') {
-        for (let i = 0; i < this.$store.getters.phoneticConflicts.length; i++) {
-          let entry = this.$store.getters.phoneticConflicts[i]
-          if (entry.class.indexOf('conflict-phonetic-title collapsible') == 0) {
-            if (entry.text == what.text) {
-              toggleIt = true
-              if (entry.class == 'conflict-phonetic-title collapsible collapsed') {
-                entry.class = 'conflict-phonetic-title collapsible expanded'
+        if (bucket == 'phonetic') {
+          for (let i = 0; i < this.$store.getters.phoneticConflicts.length; i++) {
+            let entry = this.$store.getters.phoneticConflicts[i]
+            if (entry.class.indexOf('conflict-phonetic-title collapsible') == 0) {
+              if (entry.text == what.text) {
+                toggleIt = true
+                if (entry.class == 'conflict-phonetic-title collapsible collapsed') {
+                  entry.class = 'conflict-phonetic-title collapsible expanded'
+                } else {
+                  entry.class = 'conflict-phonetic-title collapsible collapsed'
+                }
               } else {
-                entry.class = 'conflict-phonetic-title collapsible collapsed'
+                toggleIt = false
               }
-            } else {
-              toggleIt = false
             }
-          }
-          if (entry.class.indexOf('conflict-result') != -1 && toggleIt) {
-            if (entry.class.indexOf('conflict-result-hidden') != -1) {
-              entry.class = entry.class.replace('conflict-result-hidden', 'conflict-result-displayed')
-            } else {
-              entry.class = entry.class.replace('conflict-result-displayed', 'conflict-result-hidden')
+            if (entry.class.indexOf('conflict-result') != -1 && toggleIt) {
+              if (entry.class.indexOf('conflict-result-hidden') != -1) {
+                entry.class = entry.class.replace('conflict-result-hidden', 'conflict-result-displayed')
+              } else {
+                entry.class = entry.class.replace('conflict-result-displayed', 'conflict-result-hidden')
+              }
             }
           }
         }
-      }
-		},
+      },
       check_deselect() {
         if (this.$store.getters.currentConflict === this.selectedConflict) {
-          this.selectedConflict='';
-	    }
+          this.selectedConflict = '';
+        }
       },
       setConflictInfo() {
         if (this.selectedConflict != '')
           this.$store.dispatch('getConflictInfo', this.selectedConflict);
       },
       setSelectedConflict() {
-        if (this.$store.getters.currentConflict == null && this.conflictData &&
-          this.conflictData.length > 1 && this.conflictData[1].source
-        ) {
+        // find first actual result in list - looking for exact match
+        var exactMatch = this.conflictData.find(obj => {
+          return obj.class.indexOf('conflict-exact-match') >= 0;
+        });
+
+        if (this.$store.getters.currentConflict == null && this.conflictData && exactMatch !== undefined) {
           this.selectedConflict = {
-            index:1,
-            class:this.conflictData[1].class,
-            text:this.conflictData[1].text,
-            highlightedText:this.conflictData[1].highlightedText,
-            source:this.conflictData[1].source,
-            nrNumber:this.conflictData[1].nrNumber
+            class: exactMatch.class,
+            text: exactMatch.text,
+            highlightedText: exactMatch.highlightedText,
+            source: exactMatch.source,
+            nrNumber: exactMatch.nrNumber
           }
         }
         else if (this.$store.getters.currentConflict != null) {
           this.selectedConflict = this.$store.getters.currentConflict;
-	  	}
+        }
       }
 
     },
@@ -357,6 +436,11 @@
 
   .conflict-no-match {
     color: #CCC;
+  }
+
+  /* hide the No Results message when spinner is showing, ie: results are loading */
+  .spinner-wrapper:not(.hidden) + .conflict-no-match {
+    display: none;
   }
 
   .conflict-result {

--- a/client/src/components/application/Examine/Recipe/history/historyList.vue
+++ b/client/src/components/application/Examine/Recipe/history/historyList.vue
@@ -2,6 +2,9 @@
 <template>
 
     <div class="col history-list-parent-col">
+
+      <spinner className="history-spinner hidden" />
+
       <div class="row history-list-view">
 
         <select v-if="historyJSON.names.length > 0" v-model="selectedHistory" class="form-control" size="17" border="0" @click="check_deselect" tabindex="6">
@@ -21,8 +24,14 @@
 
 <script>
 /* eslint-disable */
+
+  import spinner from '@/components/application/spinner.vue';
+
   export default {
     name: 'historyList',
+    components: {
+      spinner,
+    },
     data: function() {
       return {
         selectedHistory: ''
@@ -96,6 +105,11 @@
 <style scoped>
 </style>
 <style>
+
+  /* hide the panel content when spinner is showing, ie: results are loading */
+  .spinner:not(.hidden) + .history-list-view {
+    display: none;
+  }
 
   .history-list-parent-col {
     min-width: 800px;

--- a/client/src/components/application/Examine/Recipe/trademarks/trademarksInfo.vue
+++ b/client/src/components/application/Examine/Recipe/trademarks/trademarksInfo.vue
@@ -1,15 +1,24 @@
 /* eslint-disable */
 <template>
-   <span v-on:click="setSelection($event);">
-     <p v-if='has_trademarks'><datatable v-bind="$data" /></p>
+  <span>
+    <spinner className="trademarks-spinner hidden" />
+
+    <span id="trademarks-wrapper" v-on:click="setSelection($event);">
+      <p v-if='has_trademarks'><datatable v-bind="$data" /></p>
+    </span>
   </span>
 </template>
 
 <script>
 /* eslint-disable */
 
+  import spinner from '@/components/application/spinner.vue';
+
   export default {
     name: 'trademarkInfo',
+    components: {
+      spinner,
+    },
     data: () => ({
       tblClass: ['table-bordered', 'search-table'],
       columns: [
@@ -106,7 +115,10 @@
 </script>
 
 <style scoped>
-
+  /* hide the content when spinner is showing, ie: results are loading */
+  .spinner:not(.hidden) + #trademarks-wrapper {
+    display: none;
+  }
 </style>
 
 <!-- unscoped style -->

--- a/client/src/components/application/spinner.vue
+++ b/client/src/components/application/spinner.vue
@@ -1,0 +1,31 @@
+<!-- eslint-disable -->
+<template>
+  <div :class="classes">
+    <div class="bounce1" />
+    <div class="bounce2" />
+    <div class="bounce3" />
+  </div>
+</template>
+
+<script>
+/* eslint-disable */
+
+  export default {
+    name: 'spinner',
+    data: function() {
+      return {
+      }
+    },
+    props: {
+      className: String,
+    },
+    computed: {
+      classes() {
+        var classes = 'spinner';
+        if (this.className) classes += ' ' + this.className;
+        return classes;
+      },
+    },
+  }
+</script>
+

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -787,8 +787,9 @@ export default new Vuex.Store({
   },
 
     setExactMatchesConflicts(state, jsonValue) {
-      var names = jsonValue['names']
       state.exactMatchesConflicts = []
+      if (jsonValue == null) return;
+      var names = jsonValue['names'];
       for (var i=0; i<names.length; i++) {
         var entry = names[i];
         state.exactMatchesConflicts.push({
@@ -804,6 +805,7 @@ export default new Vuex.Store({
     setSynonymMatchesConflicts(state, json) {
       state.synonymMatchesConflicts = [];
       state.synonymHighlightedMatches = [];
+      if (json == null) return;
       let names = json.names;
       let additionalRow = null;
       let entry = null;
@@ -914,6 +916,7 @@ export default new Vuex.Store({
 
     setCobrsPhoneticConflicts(state, json) {
       state.cobrsPhoneticConflicts = [];
+      if (json == null) return;
       let names = json.names;
       let additionalRow = null;
       for (let i=0; i<names.length; i++) {
@@ -977,6 +980,7 @@ export default new Vuex.Store({
 
     setPhoneticConflicts(state, json) {
       state.phoneticConflicts = [];
+      if (json == null) return;
       let names = json.names;
       let additionalRow = null;
 
@@ -1409,7 +1413,7 @@ export default new Vuex.Store({
       const myToken = sessionStorage.getItem('KEYCLOAK_TOKEN')
       const url = '/api/v1/requests/' + value.nrNumber
       const vm = this
-      return axios.get(url, {headers: {Authorization: `Bearer ${myToken}`}}).then(response => {
+      return axios.get(url, {headers: {Authorization: `Bearer ${myToken}`}, spinner: '.conflict-detail-spinner'}).then(response => {
         console.log('Names Conflict response:' + response.data)
         commit('loadNamesConflictJSON',response.data )
       })
@@ -1421,7 +1425,7 @@ export default new Vuex.Store({
       const myToken = sessionStorage.getItem('KEYCLOAK_TOKEN')
       const url = '/api/v1/corporations/' + value.nrNumber
       const vm = this
-      return axios.get(url, {headers: {Authorization: `Bearer ${myToken}`}}).then(response => {
+      return axios.get(url, {headers: {Authorization: `Bearer ${myToken}`}, spinner: '.conflict-detail-spinner'}).then(response => {
         console.log('Corp Conflict response:' + response.data)
         commit('loadCorpConflictJSON',response.data)
       })
@@ -1433,7 +1437,7 @@ export default new Vuex.Store({
       const myToken = sessionStorage.getItem('KEYCLOAK_TOKEN')
       const url = '/api/v1/requests/' + value.nr_num
       const vm = this
-      return axios.get(url, {headers: {Authorization: `Bearer ${myToken}`}}).then(response => {
+      return axios.get(url, {headers: {Authorization: `Bearer ${myToken}`}, spinner: false}).then(response => {
         console.log('History info response:' + response.data)
         commit('loadHistoriesInfoJSON',response.data )
       })
@@ -1493,6 +1497,8 @@ export default new Vuex.Store({
 
     checkManualExactMatches( {commit, state}, query ) {
 
+      commit('setExactMatchesConflicts', null);
+
       console.log('action: getting exact matches for number: ' + state.compInfo.nrNumber + ' from solr')
       query = query.replace(' \/','\/')
           .replace(/(^|\s+)(\$+(\s|$)+)+/g, '$1DOLLAR$3')
@@ -1509,7 +1515,7 @@ export default new Vuex.Store({
       const url = '/api/v1/exact-match?query='+query
       console.log('URL:' + url)
       const vm = this
-      return axios.get(url, {headers: {Authorization: `Bearer ${myToken}`}}).then(response => {
+      return axios.get(url, {headers: {Authorization: `Bearer ${myToken}`}, spinner: '.exact-match-spinner'}).then(response => {
         console.log('Check Exact Match Response:', JSON.stringify(response.data))
         commit('setExactMatchesConflicts', response.data)
       })
@@ -1517,6 +1523,8 @@ export default new Vuex.Store({
     },
 
     checkManualSynonymMatches( {dispatch,commit,state}, query ) {
+
+      commit('setSynonymMatchesConflicts', null);
 
       console.log('action: getting synonym matches for number: ' + state.compInfo.nrNumber + ' from solr')
       query = query.replace(/\//g,' ')
@@ -1534,13 +1542,15 @@ export default new Vuex.Store({
       console.log('URL:' + url);
       const vm = this;
       dispatch('checkToken');
-      return axios.get(url, {headers: {Authorization: `Bearer ${myToken}`}}).then(response => {
+      return axios.get(url, {headers: {Authorization: `Bearer ${myToken}`}, spinner: '.synonym-match-spinner'}).then(response => {
         commit('setSynonymMatchesConflicts', response.data)
       })
         .catch(error => console.log('ERROR (synonym matches): ' + error))
     },
 
     checkManualCobrsPhoneticMatches( {dispatch,commit,state}, query ) {
+
+      commit('setCobrsPhoneticConflicts', null);
 
       console.log('action: getting CobrsPhonetic matches for number: ' + state.compInfo.nrNumber + ' from solr')
       query = query.replace(/\//g,' ')
@@ -1558,13 +1568,15 @@ export default new Vuex.Store({
       console.log('URL:' + url);
       const vm = this;
       dispatch('checkToken');
-      return axios.get(url, {headers: {Authorization: `Bearer ${myToken}`}}).then(response => {
-        commit('setCobrsPhoneticConflicts', response.data)
+      return axios.get(url, {headers: {Authorization: `Bearer ${myToken}`}, spinner: '.cobrs-phonetic-match-spinner'}).then(response => {
+        commit('setCobrsPhoneticConflicts', response.data);
       })
         .catch(error => console.log('ERROR (CobrsPhonetic matches): ' + error))
     },
 
     checkManualPhoneticMatches( {dispatch,commit,state}, query ) {
+
+      commit('setPhoneticConflicts', null);
 
       console.log('action: getting Phonetic matches for number: ' + state.compInfo.nrNumber + ' from solr')
       query = query.replace(/\//g,' ')
@@ -1582,32 +1594,16 @@ export default new Vuex.Store({
       console.log('URL:' + url);
       const vm = this;
       dispatch('checkToken');
-      return axios.get(url, {headers: {Authorization: `Bearer ${myToken}`}}).then(response => {
+      return axios.get(url, {headers: {Authorization: `Bearer ${myToken}`}, spinner: '.phonetic-match-spinner'}).then(response => {
         commit('setPhoneticConflicts', response.data)
       })
         .catch(error => console.log('ERROR (Phonetic matches): ' + error))
     },
 
-    // not used
-    checkManualConflicts( {commit, state},searchStr ) {
-      console.log('action: manual check of conflicts for company number: ' + state.compInfo.nrNumber + ' from solr')
-      const myToken = sessionStorage.getItem('KEYCLOAK_TOKEN')
-      const myHeader =  {headers: {Authorization: `Bearer ${myToken}`}};
-      const url = '/api/v1/documents:conflicts'
-      console.log('URL:' + url)
-      const vm = this
-      return axios.post(url, {type: 'plain_text', content: searchStr }, myHeader).then(response => {
-        console.log('Check Manual Conflicts for ' + searchStr + ' - Response:' + response.data)
-        commit('loadConflictsJSON',response.data)
-        commit('setConflicts',response.data)
-      })
-        .catch(error => console.log('ERROR: ' + error))
-    },
-
     checkManualConditions( {commit, state},searchStr ) {
       console.log('action: manual check of restricted words and conditions for company number: ' + state.compInfo.nrNumber )
       const myToken = sessionStorage.getItem('KEYCLOAK_TOKEN')
-      const myHeader =  {headers: {Authorization: `Bearer ${myToken}`}};
+      const myHeader =  {headers: {Authorization: `Bearer ${myToken}`}, spinner: '.conditions-spinner'};
       const url = '/api/v1/documents:restricted_words'
       console.log('URL:' + url)
       const vm = this
@@ -1621,7 +1617,7 @@ export default new Vuex.Store({
     checkManualHistories( {commit, state},searchStr ) {
       console.log('action: manual check of history for company number: ' + state.compInfo.nrNumber + ' from solr')
       const myToken = sessionStorage.getItem('KEYCLOAK_TOKEN')
-      const myHeader =  {headers: {Authorization: `Bearer ${myToken}`}};
+      const myHeader =  {headers: {Authorization: `Bearer ${myToken}`}, spinner: '.history-spinner'};
       const url = '/api/v1/documents:histories'
       console.log('URL:' + url)
       searchStr = searchStr.replace(/\//g,' ')
@@ -1645,7 +1641,7 @@ export default new Vuex.Store({
     checkManualTrademarks( {commit, state},searchStr ) {
       console.log('action: manual check of trademarks for company number: ' + state.compInfo.nrNumber + ' from solr')
       const myToken = sessionStorage.getItem('KEYCLOAK_TOKEN')
-      const myHeader =  {headers: {Authorization: `Bearer ${myToken}`}};
+      const myHeader =  {headers: {Authorization: `Bearer ${myToken}`}, spinner: '.trademarks-spinner'};
       const url = '/api/v1/documents:trademarks'
       console.log('URL:' + url)
       searchStr = searchStr.replace(/\//g,' ')
@@ -1691,8 +1687,12 @@ export default new Vuex.Store({
 
     resetValues({state, commit}){
       // clear NR specific JSON data so that it can't get accidentally re-used by the next NR number
-      console.log('Deleting conflictsJSON from state')
+      console.log('Deleting conflict data from state');
       commit('loadConflictsJSON',null)
+      commit('setExactMatchesConflicts', null);
+      commit('setSynonymMatchesConflicts', null);
+      commit('setCobrsPhoneticConflicts', null);
+      commit('setPhoneticConflicts', null);
       commit('currentConflict', null)
 
       console.log('Deleting NamesConflictJSON from state')

--- a/client/static/css/main.css
+++ b/client/static/css/main.css
@@ -2385,55 +2385,56 @@ nav .form-control {
   opacity: 1;
 }
 .spinner {
-  margin: 100px auto;
-  width: 50px;
-  height: 40px;
+  margin: 100px auto 0;
+  width: 70px;
   text-align: center;
-  font-size: 10px;
 }
 
+/* main spinner, that is used to block the whole page - in conjunction with #loading-overlay */
 .spinner > div {
-  background-color: rgb(4, 25, 120);
-  height: 100%;
-  width: 6px;
+  background-color: #003366;
+  width: 18px;
+  height: 18px;
+
+  border-radius: 100%;
   display: inline-block;
-
-  -webkit-animation: sk-stretchdelay 1.2s infinite ease-in-out;
-  animation: sk-stretchdelay 1.2s infinite ease-in-out;
+  -webkit-animation: sk-bouncedelay 1.4s infinite ease-in-out both;
+  animation: sk-bouncedelay 1.4s infinite ease-in-out both;
+}
+/* mini-spinner, used inside recipe steps */
+.spinner.mini {
+  margin: 0 17px;
+  width: 70px;
+  text-align: center;
+}
+.spinner.mini > div {
+  background-color: #999;
+  width: 6px;
+  height: 6px;
 }
 
-.spinner .rect2 {
-  -webkit-animation-delay: -1.1s;
-  animation-delay: -1.1s;
+.spinner .bounce1 {
+  -webkit-animation-delay: -0.32s;
+  animation-delay: -0.32s;
 }
 
-.spinner .rect3 {
-  -webkit-animation-delay: -1.0s;
-  animation-delay: -1.0s;
+.spinner .bounce2 {
+  -webkit-animation-delay: -0.16s;
+  animation-delay: -0.16s;
 }
 
-.spinner .rect4 {
-  -webkit-animation-delay: -0.9s;
-  animation-delay: -0.9s;
+@-webkit-keyframes sk-bouncedelay {
+  0%, 80%, 100% { -webkit-transform: scale(0) }
+  40% { -webkit-transform: scale(1.0) }
 }
 
-.spinner .rect5 {
-  -webkit-animation-delay: -0.8s;
-  animation-delay: -0.8s;
-}
-
-@-webkit-keyframes sk-stretchdelay {
-  0%, 40%, 100% { -webkit-transform: scaleY(0.4) }
-  20% { -webkit-transform: scaleY(1.0) }
-}
-
-@keyframes sk-stretchdelay {
-  0%, 40%, 100% {
-    transform: scaleY(0.4);
-    -webkit-transform: scaleY(0.4);
-  }  20% {
-    transform: scaleY(1.0);
-    -webkit-transform: scaleY(1.0);
+@keyframes sk-bouncedelay {
+  0%, 80%, 100% {
+    -webkit-transform: scale(0);
+    transform: scale(0);
+  } 40% {
+    -webkit-transform: scale(1.0);
+    transform: scale(1.0);
   }
 }
 

--- a/client/test/features/specs/activities/select.condition.js
+++ b/client/test/features/specs/activities/select.condition.js
@@ -2,7 +2,7 @@ let selectCondition = (when, data)=>{
     when(/^he selects the first condition on (.*)/, (word) => {
         return new Promise((done) => {
             let row = data.vm.$el.querySelector('#condition div[name=NormalTableBody] table tr');
-            let span = data.vm.$el.querySelector('#condition span');
+            let span = data.vm.$el.querySelector('#condition #conditions-wrapper');
             expect(condition.innerHTML).toContain(word)
 
             let window = condition.ownerDocument.defaultView;

--- a/client/test/features/specs/assertions/decision.screen.conditions.js
+++ b/client/test/features/specs/assertions/decision.screen.conditions.js
@@ -1,7 +1,7 @@
 /*eslint-disable*/
 let heSeesTheSelectedConditionInDecisionScreen = (then, data)=>{
     then(/^he sees the selected condition about (.*)/, (word) => {
-        let item = data.vm.$el.querySelector('div.lower-section div.namePage span div.row div div div.multiselect div.multiselect__tags-wrap')
+        let item = data.vm.$el.querySelector('#decision-conditions-dropdown .multiselect div.multiselect__tags-wrap')
         expect(item.innerHTML).toContain(word)
     });
 }

--- a/client/test/jest/ComponentSnapshotTests/application/examine/Recipe/Trademarks/__snapshots__/TrademarksInfo.spec.js.snap
+++ b/client/test/jest/ComponentSnapshotTests/application/examine/Recipe/Trademarks/__snapshots__/TrademarksInfo.spec.js.snap
@@ -2,6 +2,14 @@
 
 exports[`TrademarksInfo.vue renders a TrademarksInfo component 1`] = `
 <span>
-  <!---->
+  <spinner-stub
+    classname="trademarks-spinner hidden"
+  />
+   
+  <span
+    id="trademarks-wrapper"
+  >
+    <!---->
+  </span>
 </span>
 `;

--- a/client/test/jest/ComponentSnapshotTests/application/examine/Recipe/conflicts/__snapshots__/ConflictInfo.spec.js.snap
+++ b/client/test/jest/ComponentSnapshotTests/application/examine/Recipe/conflicts/__snapshots__/ConflictInfo.spec.js.snap
@@ -8,6 +8,10 @@ exports[`ConflictInfo.vue renders a ConflictInfo component 1`] = `
     <div
       class="row ConflictInfo"
     >
+      <spinner-stub
+        classname="conflict-detail-spinner hidden"
+      />
+       
       <div
         class="col conflict-info-view"
       >

--- a/client/test/jest/ComponentSnapshotTests/application/examine/Recipe/conflicts/__snapshots__/ConflictList.spec.js.snap
+++ b/client/test/jest/ComponentSnapshotTests/application/examine/Recipe/conflicts/__snapshots__/ConflictList.spec.js.snap
@@ -23,12 +23,20 @@ exports[`ConflictList.vue renders a ConflictList component 1`] = `
         </div>
       </div>
       <div
+        class="exact-match-spinner spinner-wrapper hidden"
+      >
+        <spinner-stub
+          classname="mini"
+        />
+      </div>
+      <div
         class="conflict-no-match"
       >
         <div>
           No Exact Match
         </div>
       </div>
+       
       <div
         class="synonym-match-title"
       >
@@ -37,6 +45,21 @@ exports[`ConflictList.vue renders a ConflictList component 1`] = `
         </div>
       </div>
       <div
+        class="synonym-match-spinner spinner-wrapper hidden"
+      >
+        <spinner-stub
+          classname="mini"
+        />
+      </div>
+      <div
+        class="conflict-no-match"
+      >
+        <div>
+          No Match
+        </div>
+      </div>
+       
+      <div
         class="cobrs-phonetic-match-title"
       >
         <div>
@@ -44,11 +67,33 @@ exports[`ConflictList.vue renders a ConflictList component 1`] = `
         </div>
       </div>
       <div
+        class="cobrs-phonetic-match-spinner spinner-wrapper hidden"
+      >
+        <spinner-stub
+          classname="mini"
+        />
+      </div>
+      <div
+        class="conflict-no-match"
+      >
+        <div>
+          No Match
+        </div>
+      </div>
+       
+      <div
         class="phonetic-match-title"
       >
         <div>
           Phonetic Match (experimental)
         </div>
+      </div>
+      <div
+        class="phonetic-match-spinner spinner-wrapper hidden"
+      >
+        <spinner-stub
+          classname="mini"
+        />
       </div>
       <div
         class="conflict-no-match"

--- a/client/test/jest/ComponentSnapshotTests/application/examine/Recipe/history/__snapshots__/HistoryList.spec.js.snap
+++ b/client/test/jest/ComponentSnapshotTests/application/examine/Recipe/history/__snapshots__/HistoryList.spec.js.snap
@@ -4,6 +4,10 @@ exports[`HistoryList.vue renders a HistoryList component 1`] = `
 <div
   class="col history-list-parent-col"
 >
+  <spinner-stub
+    classname="history-spinner hidden"
+  />
+   
   <div
     class="row history-list-view"
   >

--- a/client/test/jest/ComponentSnapshotTests/application/examine/__snapshots__/Decision.spec.js.snap
+++ b/client/test/jest/ComponentSnapshotTests/application/examine/__snapshots__/Decision.spec.js.snap
@@ -12,7 +12,9 @@ exports[`Decision.vue renders a Decision view 1`] = `
         Conditions
       </h3>
        
-      <div>
+      <div
+        id="decision-conditions-dropdown"
+      >
         <multiselect-stub
           close-on-select="true"
           custom-label="function () { [native code] }"

--- a/client/test/unit/specs/CobrsPhoneticMatchConflicts.spec.js
+++ b/client/test/unit/specs/CobrsPhoneticMatchConflicts.spec.js
@@ -98,6 +98,9 @@ describe('CobrsPhoneticMatches', () => {
 
         it('displays cobrs-phonetic-match conflicts', ()=>{
             expect(data.vm.$el.querySelector('#conflict-list').textContent).toContain('INCREDYBLE STEPS RECORDS, INC.')
+
+            // expect not to see spinner and results at the same time
+            expect(data.vm.$el.querySelector('#conflict-list .cobrs-phonetic-match-spinner').classList.contains('hidden'));
         })
 
         it('displays cobrs-phonetics conflicts after synonym bucket list', ()=>{

--- a/client/test/unit/specs/ExactMatchConflicts.spec.js
+++ b/client/test/unit/specs/ExactMatchConflicts.spec.js
@@ -87,7 +87,10 @@ describe('Exact-Match Conflicts', () => {
         })
 
         it('displays exact-match conflicts first (after title)', ()=>{
-            expect(data.vm.$el.querySelector('#conflict-list div:nth-child(2)').textContent.trim()).toEqual('Incredible Name LTD')
+            expect(data.vm.$el.querySelector('#conflict-list > div:nth-child(3)').textContent.trim()).toEqual('Incredible Name LTD')
+
+            // expect not to see spinner and results at the same time
+            expect(data.vm.$el.querySelector('#conflict-list .exact-match-spinner').classList.contains('hidden'));
         })
 
         it('populates additional attributes as expected', ()=>{
@@ -108,7 +111,11 @@ describe('Exact-Match Conflicts', () => {
                 sessionStorage.setItem('AUTHORIZED', true)
                 router.push('/nameExamination')
                 setTimeout(()=>{
-                    expect(data.vm.$el.querySelector('#conflict-list div:nth-child(2)').textContent.trim()).toEqual('No Exact Match')
+                    // expect no-match messaging
+                    expect(data.vm.$el.querySelector('#conflict-list > div:nth-child(3)').textContent.trim()).toEqual('No Exact Match')
+
+                    // expect not to see spinner and no-match messaging at the same time
+                    expect(data.vm.$el.querySelector('#conflict-list .exact-match-spinner').classList.contains('hidden'));
                     done();
                 }, 1000)
             }, 1000)

--- a/client/test/unit/specs/PhoneticMatchConflicts.spec.js
+++ b/client/test/unit/specs/PhoneticMatchConflicts.spec.js
@@ -111,6 +111,9 @@ describe('PhoneticMatches', () => {
 
         it('displays phonetic-match conflicts', ()=>{
             expect(data.vm.$el.querySelector('#conflict-list').textContent).toContain('INKREDABLE STEPS RECORDS, INC.')
+
+            // expect not to see spinner and results at the same time
+            expect(data.vm.$el.querySelector('#conflict-list .phonetic-match-spinner').classList.contains('hidden'));
         })
 
         it('displays phonetic-match conflicts after cobrs-phonetic match list', ()=>{

--- a/client/test/unit/specs/SynonymMatchConflicts.spec.js
+++ b/client/test/unit/specs/SynonymMatchConflicts.spec.js
@@ -85,6 +85,9 @@ describe('Synonym-Match Conflicts', () => {
 
         it('displays synonym-match conflicts', ()=>{
             expect(data.vm.$el.querySelector('#conflict-list').textContent).toContain('INCREDIBLE STEPS RECORDS, INC.')
+
+            // expect not to see spinner and results at the same time
+            expect(data.vm.$el.querySelector('#conflict-list .synonym-match-spinner').classList.contains('hidden'));
         })
 
         it('displays synonym-match conflicts after exact match list', ()=>{


### PR DESCRIPTION
*Issue #:* bcgov/name-examination#115

*Description of changes:*
Removed main page-blocking spinner from recipe steps, and replaced with call-specific spinner in various sections of recipe/exam page.

This involved breaking single conflict list into four, with four
computed lists and four sections of the template.

Also clear the lists before each call to prevent old lists showing while
new list loading.

There is also some white-space changes in ConflictList.vue (clic(), unselectPreviousSelection(), expand_collapse(), and check_deselect()) that do not change functionality.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
