### PR TITLE
Changed RESET and RE-OPEN workflow based on role.

### DIFF
--- a/client/src/components/application/Examine/CompName.vue
+++ b/client/src/components/application/Examine/CompName.vue
@@ -411,19 +411,54 @@
         this.$store.commit('currentCondition', null);
       },
       reOpen() {
-        // set current state to DRAFT
-        this.$store.commit('currentState', 'DRAFT');
+        /* Workflow:
+        If EXAMINER:
+         - move to INPROGRESS
+        If EDITOR (ADMIN):
+         - move to INPROGRESS with edit screen open
+         - upon save/cancel, move to DRAFT
+         */
+        if (this.userIsAnExaminer) {
+          this.$store.commit('currentState', 'INPROGRESS');
+        }
+        else {
+          this.$store.commit('currentState', 'INPROGRESS');
+
+          // initialize user in edit mode, with previous state set so NR gets set back to draft
+          //  when user is done changing name, adding comment, etc.
+          this.$store.state.previousStateCd = 'DRAFT';
+          this.$store.state.is_editing = true;
+        }
+
+        // set reset flag so name data is managed between Namex and NRO correctly
         this.$store.commit('hasBeenReset', true);
 
         // update request in database
         this.$store.dispatch('updateRequest');
       },
       reset() {
-        // set current state to DRAFT and clear furnished flag
-        this.$store.commit('currentState', 'DRAFT');
+        /* Workflow:
+        If EXAMINER:
+         - move to INPROGRESS
+        If EDITOR (ADMIN):
+         - move to INPROGRESS with edit screen open
+         - upon save/cancel, move to DRAFT
+         */
+        if (this.userIsAnExaminer) {
+          this.$store.commit('currentState', 'INPROGRESS');
+        }
+        else {
+          this.$store.commit('currentState', 'INPROGRESS');
+
+          // initialize user in edit mode, with previous state set so NR gets set back to draft
+          //  when user is done changing name, adding comment, etc.
+          this.$store.state.previousStateCd = 'DRAFT';
+          this.$store.state.is_editing = true;
+        }
+
         this.$store.commit('furnished', 'N');
 
-        // update request in database
+        // update request in database and NRO
         this.$store.dispatch('updateRequest');
       },
       claimNR() {

--- a/client/test/unit/specs/CompName.spec.js
+++ b/client/test/unit/specs/CompName.spec.js
@@ -604,7 +604,7 @@ describe('CompName.vue', () => {
           click('#examine-reset-button');
 
           setTimeout(() => {
-            expect(instance.$store.state.currentState).toEqual("DRAFT");
+            expect(instance.$store.state.currentState).toEqual("INPROGRESS");
           }, 10)
         });
 
@@ -620,6 +620,24 @@ describe('CompName.vue', () => {
           }, 10);
         });
 
+        describe('For Editors', () => {
+          beforeEach((done) => {
+            sessionStorage.setItem('USER_ROLES', ['names_editor']);
+            vm.$store.commit('setLoginValues');
+            setTimeout(() => {
+              done();
+            }, 100)
+          });
+
+          it('NR is opened to edit screen', () => {
+            click('#examine-reset-button');
+
+            setTimeout(() => {
+              expect(instance.$store.state.is_editing).toEqual(true);
+            }, 10);
+
+          });
+        });
       }); // end RESET
 
       describe('Re-Open', ()=> {
@@ -637,7 +655,7 @@ describe('CompName.vue', () => {
           click('#examine-re-open-button');
 
           setTimeout(() => {
-            expect(instance.$store.state.currentState).toEqual("DRAFT");
+            expect(instance.$store.state.currentState).toEqual("INPROGRESS");
           }, 10)
         });
 
@@ -651,6 +669,25 @@ describe('CompName.vue', () => {
             expect(instance.$store.state.compInfo.compNames.compName1.conflict1_num).toEqual(123);
             expect(instance.$store.state.compInfo.compNames.compName2.comment.comment).toEqual("My internal decision comment.");
           }, 10);
+        });
+
+        describe('For Editors', () => {
+          beforeEach((done) => {
+            sessionStorage.setItem('USER_ROLES', ['names_editor']);
+            vm.$store.commit('setLoginValues');
+            setTimeout(() => {
+              done();
+            }, 100)
+          });
+
+          it('NR is opened to edit screen', () => {
+            click('#examine-re-open-button');
+
+            setTimeout(() => {
+              expect(instance.$store.state.is_editing).toEqual(true);
+            }, 10);
+
+          });
         });
 
       }); // end RE-OPEN


### PR DESCRIPTION
*Issue #:* bcgov/entity#118

*Description of changes:*
Changed RESET and RE-OPEN workflow based on role. See ticket for details. There is a corresponding backend change that is required for this to work correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
