### PR TITLE
Handle 500 error when put ' +' or ' ++++' at the end of the name 

### DIFF
--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -1508,6 +1508,8 @@ export default new Vuex.Store({
           .replace(/\\/g, '')
           .replace(/\//g, '')
           .replace(/(`|~|!|\||\(|\)|\[|\]|\{|\}|:|"|\^|#|%|\?)/g, '')
+          .replace(/[\+\-]{2,}/g, '')
+          .replace(/\s[\+\-]$/, '')
       const myToken = sessionStorage.getItem('KEYCLOAK_TOKEN')
       query = query.substring(0, 1) == '+' ? query.substring(1) : query;
       query = encodeURIComponent(query)

--- a/client/test/unit/specs/ExactMatchesRequest.spec.js
+++ b/client/test/unit/specs/ExactMatchesRequest.spec.js
@@ -40,7 +40,7 @@ describe('store > checkManualExactMatches', () => {
     })
 
     it('escape special characters', ()=>{
-        store.dispatch('checkManualExactMatches', '/?.><\\\'\":;\\|][}{=+_-)(*&^%$#@!~`ATHENAE/?.><\\\'\":;\\|][}{=+_-)(*&^%$#@!~`UM 139 LTD./?.><\\\'":;\\|][}{=+_-)(*&^%$#@!~`')
+        store.dispatch('checkManualExactMatches', '/?.><\\\'\":;\\|][}{=+_-)(*&^%$#@!~`ATHENAE/?.><\\\'\":;\\|][}{=+_-)(*&^%$#@!~`UM 139 LTD./?.><\\\'":;\\|][}{=+_-)(*&^%$#@!~` +++++ ------')
 
         expect(exactMatch.lastCall.args[0]).toEqual('/api/v1/exact-match?query=.%3E%3C\'%3B%3D%2B_-*%26S%40ATHENAE.%3E%3C\'%3B%3D%2B_-*%26S%40UM%20139%20LTD..%3E%3C\'%3B%3D%2B_-*%26S%40')
     })

--- a/client/test/unit/specs/ExactMatchesRequest.spec.js
+++ b/client/test/unit/specs/ExactMatchesRequest.spec.js
@@ -42,6 +42,6 @@ describe('store > checkManualExactMatches', () => {
     it('escape special characters', ()=>{
         store.dispatch('checkManualExactMatches', '/?.><\\\'\":;\\|][}{=+_-)(*&^%$#@!~`ATHENAE/?.><\\\'\":;\\|][}{=+_-)(*&^%$#@!~`UM 139 LTD./?.><\\\'":;\\|][}{=+_-)(*&^%$#@!~` +++++ ------')
 
-        expect(exactMatch.lastCall.args[0]).toEqual('/api/v1/exact-match?query=.%3E%3C\'%3B%3D%2B_-*%26S%40ATHENAE.%3E%3C\'%3B%3D%2B_-*%26S%40UM%20139%20LTD..%3E%3C\'%3B%3D%2B_-*%26S%40')
+        expect(exactMatch.lastCall.args[0]).toEqual('/api/v1/exact-match?query=.%3E%3C\'%3B%3D%2B_-*%26S%40ATHENAE.%3E%3C\'%3B%3D%2B_-*%26S%40UM%20139%20LTD..%3E%3C\'%3B%3D%2B_-*%26S%40%20%20')
     })
 })


### PR DESCRIPTION
*Issue #:  [bcgov/entity#117](https://github.com/bcgov/entity/issues/117)

*Description of changes:*
Put two new Regex replace name special characters logic in exactmatch query. 
- Remove all repeated + and - in the name (e.g. ++++ or -----)
- Remove ' +' or ' -' at then name of the name

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
