### PR TITLE
bug fix - bad stem highlighting when single letter in name.

### DIFF
--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -838,6 +838,12 @@ export default new Vuex.Store({
       let wildcard_stack = false
       for (let i=0; i<names.length; i++) {
         additionalRow = null;
+
+        // remove any empty string stem values - they are not valid
+        names[i].stems = names[i].stems.filter(function (elem) {
+          return elem != '';
+        });
+
         if (names[i].name_info.source != null) {
           //stack conflict
           entry = names[i].name_info;

--- a/client/test/unit/specs/SynonymMatchConflicts.spec.js
+++ b/client/test/unit/specs/SynonymMatchConflicts.spec.js
@@ -293,6 +293,151 @@ describe('Synonym-Match Conflicts', () => {
       }, 1000)
     })
 
+    it('handles unexpected/incorrect syn and stem data properly', (done) => {
+      data.apiSandbox.getStub.withArgs('/api/v1/requests/synonymbucket/incredible name inc', sinon.match.any).returns(
+        new Promise((resolve) => resolve({
+          data: {
+            names: [
+              {
+                name_info: {name: '----PACIFIC LUMBER CONSTRUCTION - meta1'},
+                stems: ['pacif', 'lumb', 'construct', '']
+              },
+              {
+                name_info: {
+                  id: "0193638",
+                  name: "PACIFIC LUMBER DEVELOPMENTS",
+                  score: 1.0,
+                  source: "CORP"
+                }, stems: ['pacif', 'lumb', 'develop', '']
+              },
+              {
+                name_info: {
+                  id: "0293638",
+                  name: "PACIFIC LOG CONSTRUCTION",
+                  score: 1.0,
+                  source: "CORP"
+                }, stems: ['pacif', 'log', 'construct']
+              },
+              {
+                name_info: {
+                  id: "0393638",
+                  name: "PACIFIC LOG RENOVATIONS",
+                  score: 1.0,
+                  source: "CORP"
+                }, stems: ['pacif', 'log', 'reno']
+              },
+              {
+                name_info: {name: '----PACIFIC LUMBER (CONSTRUCTION) - meta2'},
+                stems: ['pacif', 'lumb', '', '']
+              },
+              {
+                name_info: {
+                  id: "0493638",
+                  name: "PACIFIC LUMBER WORD1 WORD2 WORD3 WORD4 RENOVATIONS",
+                  score: 1.0,
+                  source: "CORP"
+                }, stems: ['pacif', 'lumb', 'reno', '', ' ']
+              },
+              {name_info: {name: '----PACIFIC (LUMBER, CONSTRUCTION) - meta3'}, stems: ['pacif']},
+              {
+                name_info: {
+                  id: "0593638",
+                  name: "PACIFIC WORD1 WORD2 WORD3 WORD4 LUMBER RENOVATIONS",
+                  score: 1.0,
+                  source: "CORP"
+                }, stems: ['pacif', 'lumb', 'reno']
+              },
+            ]
+          }
+        }))
+      )
+      const Constructor = Vue.extend(App);
+      data.instance = new Constructor({store: store, router: router});
+      data.vm = data.instance.$mount(document.getElementById('app'));
+      setTimeout(() => {
+        data.instance.$store.state.userId = 'Joe'
+        sessionStorage.setItem('AUTHORIZED', true)
+        router.push('/nameExamination')
+        setTimeout(() => {
+          expect(data.instance.$store.state.synonymMatchesConflicts).toEqual([
+            {
+              "class": "conflict-synonym-title collapsible expanded",
+              "count": 3,
+              "highlightedText": "<span class=\"stem-highlight\"> PACIF</span>IC<span class=\"stem-highlight\"> LUMB</span>ER<span class=\"stem-highlight\"> CONSTRUCT</span>ION",
+              "meta": "meta1",
+              "nrNumber": undefined,
+              "source": undefined,
+              "text": "PACIFIC LUMBER CONSTRUCTION"
+            },
+            {
+              "class": "conflict-result conflict-result-displayed",
+              "count": 0,
+              "highlightedText": "<span class=\"stem-highlight\"><span class=\"synonym-stem-highlight\"> PACIF</span></span>IC<span class=\"stem-highlight\"><span class=\"synonym-stem-highlight\"> LUMB</span></span>ER<span class=\"synonym-stem-highlight\"> DEVELOP</span>MENTS",
+              "meta": undefined,
+              "nrNumber": "0193638",
+              "source": "CORP",
+              "text": "PACIFIC LUMBER DEVELOPMENTS"
+            },
+            {
+              "class": "conflict-result conflict-result-displayed",
+              "count": 0,
+              "highlightedText": "<span class=\"stem-highlight\"><span class=\"synonym-stem-highlight\"> PACIF</span></span>IC<span class=\"synonym-stem-highlight\"> LOG</span><span class=\"stem-highlight\"><span class=\"synonym-stem-highlight\"> CONSTRUCT</span></span>ION",
+              "meta": undefined,
+              "nrNumber": "0293638",
+              "source": "CORP",
+              "text": "PACIFIC LOG CONSTRUCTION"
+            },
+            {
+              "class": "conflict-result conflict-result-displayed",
+              "count": 0,
+              "highlightedText": "<span class=\"stem-highlight\"><span class=\"synonym-stem-highlight\"> PACIF</span></span>IC<span class=\"synonym-stem-highlight\"> LOG</span><span class=\"synonym-stem-highlight\"> RENO</span>VATIONS",
+              "meta": undefined,
+              "nrNumber": "0393638",
+              "source": "CORP",
+              "text": "PACIFIC LOG RENOVATIONS"
+            },
+            {
+              "class": "conflict-synonym-title collapsible collapsed",
+              "count": 1,
+              "highlightedText": "<span class=\"stem-highlight\"><span class=\"synonym-stem-highlight\"> PACIF</span></span>IC<span class=\"stem-highlight\"> LUMB</span>ER (CONSTRUCTION)",
+              "meta": "meta2",
+              "nrNumber": undefined,
+              "source": undefined,
+              "text": "PACIFIC LUMBER (CONSTRUCTION)"
+            },
+            {
+              "class": "conflict-result conflict-result-hidden",
+              "count": 0,
+              "highlightedText": "<span class=\"stem-highlight\"><span class=\"synonym-stem-highlight\"> PACIF</span></span>IC<span class=\"stem-highlight\"><span class=\"synonym-stem-highlight\"> LUMB</span></span>ER WORD1 WORD2 WORD3 WORD4<span class=\"synonym-stem-highlight\"> RENO</span>VATIONS",
+              "meta": undefined,
+              "nrNumber": "0493638",
+              "source": "CORP",
+              "text": "PACIFIC LUMBER WORD1 WORD2 WORD3 WORD4 RENOVATIONS"
+            },
+            {
+              "class": "conflict-synonym-title collapsible collapsed",
+              "count": 1,
+              "highlightedText": "<span class=\"stem-highlight\"><span class=\"synonym-stem-highlight\"> PACIF</span></span>IC (LUMBER, CONSTRUCTION)",
+              "meta": "meta3",
+              "nrNumber": undefined,
+              "source": undefined,
+              "text": "PACIFIC (LUMBER, CONSTRUCTION)"
+            },
+            {
+              "class": "conflict-result conflict-result-hidden",
+              "count": 0,
+              "highlightedText": "<span class=\"stem-highlight\"><span class=\"synonym-stem-highlight\"> PACIF</span></span>IC WORD1 WORD2 WORD3 WORD4<span class=\"synonym-stem-highlight\"> LUMB</span>ER<span class=\"synonym-stem-highlight\"> RENO</span>VATIONS",
+              "meta": undefined,
+              "nrNumber": "0593638",
+              "source": "CORP",
+              "text": "PACIFIC WORD1 WORD2 WORD3 WORD4 LUMBER RENOVATIONS"
+            }
+          ])
+          done();
+        }, 1000)
+      }, 1000)
+    })
+
     it('changes conflicts tab to red', (done) => {
       const Constructor = Vue.extend(App);
       data.instance = new Constructor({store: store, router: router});


### PR DESCRIPTION
*Issue #:* bcgov/entity#182

*Description of changes:*
Bug fix for bad stem highlighting when single letter in name. This is actually just handling bad data (empty string) in stems list coming from API.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
