### PR TITLE
reset exact phrase text box on getnext, page load and new name choice

### DIFF
--- a/client/src/components/application/Examine/CompName.vue
+++ b/client/src/components/application/Examine/CompName.vue
@@ -359,6 +359,7 @@
       // and coming back to same NR
       this.searching = true;
       this.setManualSearchStr(this.currentName);
+      this.exactPhrase = '';
     },
     methods: {
       /**
@@ -472,7 +473,6 @@
       },
       runManualRecipe(){
         console.log("Running manual recipe on " + this.searchStr + '/' + this.exactPhrase);
-        console.log('HERE2: ', this.exactPhrase)
         this.$store.dispatch('runManualRecipe', {searchStr:this.searchStr, exactPhrase:this.exactPhrase});
       },
       setIcon(name_state) {
@@ -537,7 +537,6 @@
       onSubmit()
       {
         this.$store.dispatch('resetValues');
-        console.log('HERE1: ', this.exactPhrase)
         this.$store.dispatch('runManualRecipe', {searchStr:this.searchStr, exactPhrase:this.exactPhrase});
 
         if (this.searchStr != this.currentName) this.is_running_manual_search = true;
@@ -602,6 +601,7 @@
         console.log('CompName.currentName watcher fired:' + val)
         this.searching = true;
         this.setManualSearchStr(val);
+        this.exactPhrase = '';
       },
       nrNumber: function (val) {
         console.log('CompName.nrNumber watcher fired:' + val)


### PR DESCRIPTION
Signed-off-by: Kial Jinnah <kialj876@gmail.com>

*Issue #:bcgov/entity#108*

*Description of changes:*
- reset exact phrase text box on getnext, page load and new name choice

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
