### PR TITLE
#139 - fixed vue error caused by duplicate comment id as vue key

### DIFF
--- a/client/src/components/application/Examine/InternalComments.vue
+++ b/client/src/components/application/Examine/InternalComments.vue
@@ -9,7 +9,7 @@
       </div>
       <div class="col">
         <div class="comment" v-for="comment in internalComments"
-             v-bind:key="comment.timestamp">
+             v-bind:key="comment.id">
           <p>
             <span class="comment-examiner">{{ comment.examiner }}</span>
             -

--- a/client/src/components/application/Examine/RequestInfoHeader.vue
+++ b/client/src/components/application/Examine/RequestInfoHeader.vue
@@ -56,7 +56,7 @@
             <div>
               <h3>INTERNAL COMMENTS</h3>
               <div class="comment" v-for="comment in internalComments"
-                   v-bind:key="comment.timestamp">
+                   v-bind:key="comment.id">
                 <p>
                   <span class="comment-examiner">{{ comment.examiner }}</span>
                   -


### PR DESCRIPTION
*Issue #:* bcgov/entity#139

*Description of changes:*
Fixed vue error (console error, not functional bug) caused by vue using comment timestamp as a conceptual key, which can have duplicates.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
