### PR TITLE
fixed bug where put call to api would set expiry date if null

### DIFF
--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -718,9 +718,13 @@ export default new Vuex.Store({
       //state.reservationCount = dbcompanyInfo.reservationCount
       state.nrData.lastUpdate = state.lastUpdate
 
-      var expiryDate = new Date(state.expiryDate)
-      var expiryDateUTC = new Date(expiryDate.setHours(0,0))
-      state.nrData.expirationDate = expiryDateUTC.toUTCString()
+      if (state.expiryDate != null) {
+        var expiryDate = new Date(state.expiryDate);
+        var expiryDateUTC = new Date(expiryDate.setHours(0, 0));
+        state.nrData.expirationDate = expiryDateUTC.toUTCString();
+      } else {
+        state.nrData.expirationDate = state.expiryDate;
+      }
       state.nrData.submittedDate = state.submittedDate
       state.nrData.submitCount = state.submitCount
       state.nrData.previousNr = state.previousNr


### PR DESCRIPTION
Signed-off-by: Kial Jinnah <kialj876@gmail.com>

*Issue #:bcgov/entity#320*

*Description of changes:*
- checks if expiry date is null before reseting the hours

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
