### PR TITLE
Fixed the action of the alt-a hotkey

### DIFF
--- a/client/src/components/application/Examine/Decision.vue
+++ b/client/src/components/application/Examine/Decision.vue
@@ -222,13 +222,14 @@
       </v-flex>
       <v-flex style="position: relative; top: 20px;">
         <div class="decision-flex-holder top-margin-12">
+          <!--both the Approve and Quick Approve buttons show shortkey 'alt a'. Since these elements are
+          always simultaneously displayed and never separately, only implementing the 'alt a' shortkey logic once.  See
+          CompName.vue for this.-->
           <v-btn :disabled="!is_making_decision"
                  @click="nameAccept"
-                 @shortkey="nameAccept"
                  class="mx-1 pa-0 action-button"
                  flat
-                 id="decision-approve-button"
-                 v-shortkey="['alt', 'a']">
+                 id="decision-approve-button">
             <img id="conditional-accept-button"
                  v-if="acceptanceWillBeConditional"
                  src="/static/images/buttons/cond-approve-name.png" />


### PR DESCRIPTION
Fixed the action of the alt-a hotkey so that it performs the same action as the quick-approve button (ie. it clears the message in the window and approves)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
