### PR TITLE
entity-3290 & entity-3299

### DIFF
--- a/client/src/components/application/Examine/ActionButtons.vue
+++ b/client/src/components/application/Examine/ActionButtons.vue
@@ -313,6 +313,8 @@ export default {
         this.$store.state.previousStateCd = 'DRAFT';
         this.$store.state.is_editing = true;
       }
+      this.$store.state.nrData.consent_dt = null
+      this.$store.commit('resetConsent')
 
       this.$store.commit('furnished', 'N');
 

--- a/client/src/components/application/Examine/CompName.vue
+++ b/client/src/components/application/Examine/CompName.vue
@@ -432,13 +432,11 @@
         this.runManualRecipe()
       },
       quickApprove() {
-        this.currentNameObj.decision_text = ''
-
+        this.$store.commit('selectedConflicts', [])
         this.decision_made = 'APPROVED'
         this.nameAcceptReject()
       },
       rejectDescriptive() {
-
         this.currentNameObj.decision_text = 'Require descriptive second word or phrase * E.G. ' +
           'Construction, Gardening, Investments, Holdings, Etc.'
         this.decision_made = 'REJECTED'

--- a/client/static/css/main.css
+++ b/client/static/css/main.css
@@ -2800,6 +2800,11 @@ nav .form-control {
 
 /* FORM VALIDATION */
 
+.form-group-error {
+  background-color: unset !important;
+  color: white !important
+}
+
 .form-group-error h3 {
   color: #cc0000;
 }

--- a/client/static/ui_dropdowns/requesttype.json
+++ b/client/static/ui_dropdowns/requesttype.json
@@ -574,5 +574,14 @@
 		"LEGACY_CD": "TMY",
 		"ADDITIONAL_INFO": "",
 		"SOURCE_APPLICATION": ""
-	}
+	},
+  {
+    "value": "BC",
+    "SHORT_DESC": "Benefit Company",
+    "text": "Benefit Company - Incorporation",
+    "CLASS_TYPE_CD": "CORP",
+    "LEGACY_CD": "BC",
+    "ADDITIONAL_INFO": "",
+    "SOURCE_APPLICATION": "COLIN"
+  }
 ]


### PR DESCRIPTION
### entity 3290 - Add benefit company
- added `request_type_cd === 'BC'` to front-end list data

### entity 3299 - Added Consent Field
- added Consent field to consume the new `consent_dt` and `consentFlag` fields returned by backend
- fixed timezone issue with expirationDate

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
