### PR TITLE
entity 3976 - fix consumed status and buttons

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -68,6 +68,7 @@ export default {
       },
       showWordClassification() {
         let { baseURL } = this.$store.state
+        if (!baseURL) return false
         if (baseURL.includes('-test') || baseURL.includes('-dev')) {
           return true
         }

--- a/client/src/components/application/Examine/CompName.vue
+++ b/client/src/components/application/Examine/CompName.vue
@@ -81,7 +81,7 @@
     </v-flex>
 
     <!--EXAMINATION AREA:  RECIPE CARDS DECISION INFO-->
-    <template v-if="!is_complete">
+    <template v-if="!is_complete && !reservedOrCondReserved">
 
       <!--LEFT COLUMN:  CONFLICTS/CONDITIONS/HISTORY/TRADEMARKS LISTS-->
       <v-flex lg6 py-4 pl-5 bg-grey style="z-index: 2">
@@ -255,6 +255,10 @@
         set(value) {
           this.$store.commit('decision_made', value)
         }
+      },
+      reservedOrCondReserved () {
+        if (['COND-RESERVE', 'RESERVED'].includes(this.$store.getters.nr_status)) return true
+        return false
       },
       is_complete() {
         return this.$store.getters.is_complete

--- a/client/src/components/application/Examine/RequestInfoHeader.vue
+++ b/client/src/components/application/Examine/RequestInfoHeader.vue
@@ -403,6 +403,7 @@
         return ''
       },
       can_edit() {
+        if (this.is_consumed) return false
         if (this.is_my_current_nr) return true
         if (this.$store.getters.userHasEditRole && ['DRAFT', 'HOLD', 'REJECTED', 'APPROVED', 'CONDITIONAL'].indexOf(this.nr_status) > -1) return true
         return false
@@ -504,10 +505,7 @@
         },
       },
       is_consumed() {
-        if (this.consumptionDate && (this.nr_status === 'APPROVED' || this.nr_status === 'CONDITION')) {
-          return true
-        }
-        return false
+        return !!this.consumptionDate
       },
       internalComments_length() {
         if (this.$store.getters.internalComments) {

--- a/client/test/jest/ComponentSnapshotTests/__snapshots__/App.spec.js.snap
+++ b/client/test/jest/ComponentSnapshotTests/__snapshots__/App.spec.js.snap
@@ -21,6 +21,8 @@ exports[`App.vue  renders the App 1`] = `
       />
     </div>
      
+    <!---->
+     
     <v-dialog-stub
       class="pa-0"
       contentclass="shift-dialog-up"

--- a/client/test/jest/ComponentSnapshotTests/application/examine/__snapshots__/RequestInfoHeader.spec.js.snap
+++ b/client/test/jest/ComponentSnapshotTests/application/examine/__snapshots__/RequestInfoHeader.spec.js.snap
@@ -175,8 +175,6 @@ exports[`RequestInfoHeader.vue renders a RequestInfoHeader component 1`] = `
            
           <!---->
            
-          <!---->
-           
           <v-flex-stub
             class="grey--text"
             tag="div"


### PR DESCRIPTION
- changed logic to correctly affix the "-CONSUMED" label to all NRs which are consumed.  
- When an NR is consumed, only "Get Next" and "Show Details" buttons are available.
- Same as above applies to NRs with "RESERVED", "COND-RESERVED" and "HISTORICAL" status

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
