### PR TITLE
Added transactions mapping and staff comment

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "namex",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "namex",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "BC Registry: Name Examination",
   "author": "Thor Wolpert <thor@wolpert.ca>",
   "private": true,

--- a/client/src/components/application/Examine/RequestInfoHeader.vue
+++ b/client/src/components/application/Examine/RequestInfoHeader.vue
@@ -357,9 +357,9 @@
         jurisdiction_required: false,
         nwpta_required: false,
         prev_nr_required: false,
-        RequestActionCode: RequestActionCode,
-        RequestTypeCode: RequestTypeCode,
-        EntityTypeCode: EntityTypeCode
+        RequestActionCode,
+        RequestTypeCode,
+        EntityTypeCode
       }
     },
     computed: {

--- a/client/src/components/application/Transactions.vue
+++ b/client/src/components/application/Transactions.vue
@@ -96,7 +96,7 @@
             v-for="(transaction, index) in filteredTransactions"
             :key="index"
             class="transaction-item"
-          >
+          >{{transaction.comment = 'Testing testing 123 Testing testing 123 Testing testing 123 Testing testing 123 Testing testing 123 '}}
             <!-- Line 1 -->
             <v-layout>
               <v-flex xs3 class="fw-700">Date/Time:</v-flex>
@@ -130,7 +130,11 @@
               <v-flex xs3 class="fw-700">Request Type:</v-flex>
               <v-flex xs4 class="request-type">
                 {{ requestType_desc(
-                getMappedRequestType(transaction.requestTypeCd, transaction.request_action_cd, nrInfo.entity_type_cd))
+                    getMappedRequestType(
+                      transaction.requestTypeCd,
+                      transaction.request_action_cd,
+                      nrInfo.entity_type_cd
+                    ))
                 }}
               </v-flex>
               <v-flex xs2 class="fw-700">Consent:</v-flex>

--- a/client/src/components/application/Transactions.vue
+++ b/client/src/components/application/Transactions.vue
@@ -96,7 +96,7 @@
             v-for="(transaction, index) in filteredTransactions"
             :key="index"
             class="transaction-item"
-          >{{transaction.comment = 'Testing testing 123 Testing testing 123 Testing testing 123 Testing testing 123 Testing testing 123 '}}
+          >
             <!-- Line 1 -->
             <v-layout>
               <v-flex xs3 class="fw-700">Date/Time:</v-flex>


### PR DESCRIPTION
*Issue #:* bcgov/entity#8248

*Description of changes:*
* Included mapping in transaction history list for split request types.
* Applied staff comments to transactions history.

*Notes:*
* The api side of this additional `comment` property is still in code review for Namex.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
