### PR TITLE
11772 Update societies change of name NR consume issue

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -7,7 +7,6 @@ yarn-error.log*
 /test/unit/coverage/
 /test/e2e/reports/
 selenium-debug.log
-package-lock.json
 /static/keycloak/
 
 # Editor directories and files

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "namex",
-  "version": "2.1.11",
+  "version": "2.1.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "namex",
-  "version": "2.1.11",
+  "version": "2.1.12",
   "description": "BC Registry: Name Examination",
   "author": "Thor Wolpert <thor@wolpert.ca>",
   "private": true,

--- a/client/src/components/application/Examine/RequestInfoHeader.vue
+++ b/client/src/components/application/Examine/RequestInfoHeader.vue
@@ -141,10 +141,10 @@
               </v-layout>
             </v-flex>
             <v-flex v-else class="grey--text"><b>Expiry:</b> n/a</v-flex>
-            <v-flex :class="!consumptionDate ? 'grey--text' : ''">
+            <v-flex id="consumption-date" :class="!consumptionDate ? 'grey--text' : ''">
               <b>Consumed:</b> {{ consumptionDate || 'n/a' }}
             </v-flex>
-            <v-flex :class="!consumedBy ? 'grey--text' : ''">
+            <v-flex id="consumed-by" :class="!consumedBy ? 'grey--text' : ''">
               <b>Consumed by:</b> {{ consumedBy || 'n/a' }}
             </v-flex>
             <template v-if="nr_status === 'CONDITIONAL' && showConsent">

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -1105,14 +1105,21 @@ export const getters = {
   },
   consumedBy(state) {
     let consumedBy = ''
-    if ( state.compInfo.compNames.compName1.corpNum != null ) {
+
+    // Note: consumptionDate checks were added as NRs from Society include corpNum even when the NR hasn't been
+    // consumed yet.  This was causing consumed by field to be populated and caused confusion for examiners.
+    if ( state.compInfo.compNames.compName1.corpNum != null &&
+         !!state.compInfo.compNames.compName1.consumptionDate) {
       consumedBy = state.compInfo.compNames.compName1.corpNum
     }
-    else if ( state.compInfo.compNames.compName2.corpNum != null ) {
+    else if ( state.compInfo.compNames.compName2.corpNum != null &&
+              !!state.compInfo.compNames.compName2.consumptionDate) {
       consumedBy = state.compInfo.compNames.compName2.corpNum
     }
     else {
-      consumedBy = state.compInfo.compNames.compName3.corpNum
+      if ( !!state.compInfo.compNames.compName3.consumptionDate ) {
+        consumedBy = state.compInfo.compNames.compName3.corpNum
+      }
     }
 
     return consumedBy

--- a/client/test/unit/specs/RequestInfoHeader.spec.js
+++ b/client/test/unit/specs/RequestInfoHeader.spec.js
@@ -955,4 +955,231 @@ describe('RequestInfoHeader', () => {
       expect(vm.$el.querySelector('#nr-details-edit-button')).not.toBeNull()
     })
   })
+
+  describe('When a CONDITIONAL NR with corpNum is loaded', () => {
+    let vm
+    let sandbox
+
+    let getCall
+
+    beforeEach(async () => {
+      sandbox = sinon.createSandbox()
+      getCall = sandbox.stub(axios, 'get').withArgs('/api/v1/requests/NR 2000111', sinon.match.any).returns(
+        new Promise((resolve) => resolve({
+          data:
+            {
+              "additionalInfo": "**Change of Name** **S1000744** ",
+              "applicants": {
+                "addrLine1": "200 - 940 BLANSHARD ST",
+                "addrLine2": null,
+                "addrLine3": null,
+                "city": "VICTORIA",
+                "clientFirstName": null,
+                "clientLastName": null,
+                "contact": "John Test",
+                "countryTypeCd": "CA",
+                "declineNotificationInd": "N",
+                "emailAddress": "testoutputs@gov.bc.ca",
+                "faxNumber": null,
+                "firstName": "John",
+                "lastName": "test",
+                "middleName": "a",
+                "partyId": 1822,
+                "phoneNumber": "2505555555",
+                "postalCd": "V8V4K8",
+                "stateProvinceCd": "BC"
+              },
+              "checkedOutBy": null,
+              "checkedOutDt": null,
+              "comments": [],
+              "consentFlag": "Y",
+              "consent_dt": null,
+              "corpNum": "S1000744",
+              "entity_type_cd": null,
+              "expirationDate": "2022-06-02T06:59:00+00:00",
+              "furnished": "Y",
+              "hasBeenReset": false,
+              "homeJurisNum": null,
+              "id": 2264301,
+              "lastUpdate": "2022-04-06T17:34:10.209632+00:00",
+              "names": [
+                {
+                  "choice": 1,
+                  "comment": null,
+                  "conflict1": "",
+                  "conflict1_num": "",
+                  "conflict2": "",
+                  "conflict2_num": "",
+                  "conflict3": "",
+                  "conflict3_num": "",
+                  "consumptionDate": null,
+                  "corpNum": "S1000744",
+                  "decision_text": "BC - Use of 'British Columbia' requires consent from:  The Office of Protocol. Approval Takes 7 - 10 Business Days.  Applications Forms at http://gov.bc.ca/useofbcname. Please scan your consent to bcregistries@gov.bc.ca\n\n",
+                  "designation": null,
+                  "id": 4265876,
+                  "name": "xyz NEWLY NAMED SOCIETY",
+                  "name_type_cd": null,
+                  "state": "CONDITION"
+                }
+              ],
+              "natureBusinessInfo": "stuff",
+              "notifiedBeforeExpiry": false,
+              "notifiedExpiry": false,
+              "nrNum": "NR 2000111",
+              "nwpta": [],
+              "previousNr": null,
+              "previousRequestId": null,
+              "previousStateCd": null,
+              "priorityCd": "N",
+              "priorityDate": null,
+              "requestTypeCd": "CSO",
+              "request_action_cd": null,
+              "source": "NRO",
+              "state": "CONDITIONAL",
+              "stateCd": "CONDITIONAL",
+              "submitCount": 1,
+              "submittedDate": "2022-04-06T17:29:51+00:00",
+              "submitter_userid": "",
+              "tradeMark": null,
+              "userId": "tester",
+              "xproJurisdiction": null
+            },
+        })),
+      )
+      vm = instance.$mount()
+      vm.$store.commit('setLoginValues')
+      vm.$store.commit('nrNumber', 'NR 2000111')
+      await sleep(1000)
+    })
+
+    afterEach(() => {
+      sandbox.restore()
+    })
+
+    it('Displays the Proper NR Status Text', () => {
+      expect(vm.nr_status).toEqual('CONDITIONAL')
+      expect(vm.$el.querySelector('#nrStatusText').textContent.trim()).toEqual('CONDITIONAL')
+    })
+
+    it('Displays consume fields properly', () => {
+      expect(vm.consumptionDate).toEqual('')
+      expect(vm.$el.querySelector('#consumption-date').textContent.trim()).toEqual('Consumed: n/a')
+      expect(vm.consumedBy).toEqual('')
+      expect(vm.$el.querySelector('#consumed-by').textContent.trim()).toEqual('Consumed by: n/a')
+    })
+  })
+
+  describe('When a CONSUMED NR with corpNum is loaded', () => {
+    let vm
+    let sandbox
+
+    let getCall
+
+    beforeEach(async () => {
+      sandbox = sinon.createSandbox()
+      getCall = sandbox.stub(axios, 'get').withArgs('/api/v1/requests/NR 2000222', sinon.match.any).returns(
+        new Promise((resolve) => resolve({
+          data:
+            {
+              "additionalInfo": "**Change of Name** **S1000744** ",
+              "applicants": {
+                "addrLine1": "200 - 940 BLANSHARD ST",
+                "addrLine2": null,
+                "addrLine3": null,
+                "city": "VICTORIA",
+                "clientFirstName": null,
+                "clientLastName": null,
+                "contact": "John Test",
+                "countryTypeCd": "CA",
+                "declineNotificationInd": "N",
+                "emailAddress": "testoutputs@gov.bc.ca",
+                "faxNumber": null,
+                "firstName": "John",
+                "lastName": "test",
+                "middleName": "a",
+                "partyId": 1822,
+                "phoneNumber": "2505555555",
+                "postalCd": "V8V4K8",
+                "stateProvinceCd": "BC"
+              },
+              "checkedOutBy": null,
+              "checkedOutDt": null,
+              "comments": [],
+              "consentFlag": "Y",
+              "consent_dt": null,
+              "corpNum": "S1000744",
+              "entity_type_cd": null,
+              "expirationDate": "2022-06-02T06:59:00+00:00",
+              "furnished": "Y",
+              "hasBeenReset": false,
+              "homeJurisNum": null,
+              "id": 2264301,
+              "lastUpdate": "2022-04-06T17:34:10.209632+00:00",
+              "names": [
+                {
+                  "choice": 1,
+                  "comment": null,
+                  "conflict1": "",
+                  "conflict1_num": "",
+                  "conflict2": "",
+                  "conflict2_num": "",
+                  "conflict3": "",
+                  "conflict3_num": "",
+                  "consumptionDate": "2021-10-27T12:45:22+00:00",
+                  "corpNum": "S1000744",
+                  "decision_text": "BC - Use of 'British Columbia' requires consent from:  The Office of Protocol. Approval Takes 7 - 10 Business Days.  Applications Forms at http://gov.bc.ca/useofbcname. Please scan your consent to bcregistries@gov.bc.ca\n\n",
+                  "designation": null,
+                  "id": 4265876,
+                  "name": "xyz NEWLY NAMED SOCIETY",
+                  "name_type_cd": null,
+                  "state": "CONDITION"
+                }
+              ],
+              "natureBusinessInfo": "stuff",
+              "notifiedBeforeExpiry": false,
+              "notifiedExpiry": false,
+              "nrNum": "NR 2000222",
+              "nwpta": [],
+              "previousNr": null,
+              "previousRequestId": null,
+              "previousStateCd": null,
+              "priorityCd": "N",
+              "priorityDate": null,
+              "requestTypeCd": "CSO",
+              "request_action_cd": null,
+              "source": "NRO",
+              "state": "CONSUMED",
+              "stateCd": "CONSUMED",
+              "submitCount": 1,
+              "submittedDate": "2022-04-06T17:29:51+00:00",
+              "submitter_userid": "",
+              "tradeMark": null,
+              "userId": "tester",
+              "xproJurisdiction": null
+            },
+        })),
+      )
+      vm = instance.$mount()
+      vm.$store.commit('setLoginValues')
+      vm.$store.commit('nrNumber', 'NR 2000222')
+      await sleep(1000)
+    })
+
+    afterEach(() => {
+      sandbox.restore()
+    })
+
+    it('Displays the Proper NR Status Text', () => {
+      expect(vm.nr_status).toEqual('CONSUMED')
+      expect(vm.$el.querySelector('#nrStatusText').textContent.trim()).toEqual('CONDITIONAL APPROVED-CONSUMED')
+    })
+
+    it('Displays consume fields properly', () => {
+      expect(vm.consumptionDate).toEqual('2021-10-27')
+      expect(vm.$el.querySelector('#consumption-date').textContent.trim()).toEqual('Consumed: 2021-10-27')
+      expect(vm.consumedBy).toEqual('S1000744')
+      expect(vm.$el.querySelector('#consumed-by').textContent.trim()).toEqual('Consumed by: S1000744')
+    })
+  })
+
 })


### PR DESCRIPTION
Issue #: /bcgov/entity#11772

*Description of changes:*

* Update getter for `consumedBy` to only return value when NR is not consumed.  Normally this is not an issue as the corp num is not populated for unconsumed NRs but Society NRs include the corp num even before the NR has been consumed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
