### PR TITLE
Fixed consent required issue

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "namex",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Webpack 5, Vue.js",
   "main": "main.js",
   "author": "Per Olsen",

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -1359,9 +1359,10 @@ export const getters = {
   selectedConflictNRs: state => state.selectedConflictNRs,
   selectedReasons: state => state.selectedReasons,
   acceptanceWillBeConditional: state => {
+    const noConsentRequiredConditions = ['PERSONAL REAL ESTATE CORPORATION', 'PERSONAL REAL ESTATE', 'PERSONAL REAL']
     let checkConditions = () => {
       if (state.selectedConditions && Array.isArray(state.selectedConditions) ) {
-        return state.selectedConditions.some(condition => condition.consent_required)
+        return (state.selectedConditions.some(condition => condition.consent_required) && !(noConsentRequiredConditions.includes(state.selectedConditions[0].phrase)))
       }
       return false
     }


### PR DESCRIPTION
*Issue #:15760*

*Description of changes:*
There was an issue where consent was displayed as “required” when the consent box was not checked, for the PREC condition. It seems the macro would need to be copy/pasted or typed manually to proceed without producing the “consent: required” status. This fixes that issue by adding an additional check for when the acceptanceWillBeConditional flag will be on. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
