### PR TITLE
15642 add 'CONDITION' status to current choice

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "namex",
-  "version": "2.1.14",
+  "version": "2.1.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "namex",
-      "version": "2.1.14",
+      "version": "2.1.18",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "namex",
-  "version": "2.1.17",
+  "version": "2.1.18",
   "description": "Webpack 5, Vue.js",
   "main": "main.js",
   "author": "Per Olsen",

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -1742,7 +1742,7 @@ export const mutations = {
           state.compInfo.compNames.compName1.comment = record.comment
 
           // if this name is not yet examined or it is approved (in case of reset/re-open), set it as current name
-          if ( record.state == 'NE' || record.state == 'APPROVED' ) {
+          if ( record.state == 'NE' || record.state == 'APPROVED' || record.state == 'CONDITION' ) {
 
             this.dispatch( 'setCurrentName', record )
           }
@@ -1764,7 +1764,7 @@ export const mutations = {
           state.compInfo.compNames.compName2.comment = record.comment
 
           // if this name is not yet examined or it is approved (in case of reset/re-open), set it as current name
-          if ( ( record.state == 'NE' || record.state == 'APPROVED' ) &&
+          if ( ( record.state == 'NE' || record.state == 'APPROVED' || record.state == 'CONDITION' ) &&
             ( record.choice < state.currentChoice || state.currentChoice == null ) )
           {
 
@@ -1788,7 +1788,7 @@ export const mutations = {
           state.compInfo.compNames.compName3.comment = record.comment
 
           // if this name is not yet examined or it is approved (in case of reset/re-open), set it as current name
-          if ( ( record.state == 'NE' || record.state == 'APPROVED' ) &&
+          if ( ( record.state == 'NE' || record.state == 'APPROVED' || record.state == 'CONDITION' ) &&
             ( record.choice < state.currentChoice || state.currentChoice == null ) )
           {
             this.dispatch( 'setCurrentName', record )


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/15642

*Description of changes:*
add "current_state == 'CONDITION'" as one of the conditions for the 'current' name when loading a request

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
