### PR TITLE
Fix cached application banner

### DIFF
--- a/plugins/firebase.client.ts
+++ b/plugins/firebase.client.ts
@@ -19,7 +19,7 @@ export default defineNuxtPlugin(async (nuxtApp) => {
   const remoteConfig = getRemoteConfig(app)
 
   remoteConfig.settings.fetchTimeoutMillis = 60000
-  remoteConfig.settings.minimumFetchIntervalMillis = 3600000
+  remoteConfig.settings.minimumFetchIntervalMillis = 60000
 
   remoteConfig.defaultConfig = {
     [FeatureFlags.NAMEX_BANNER]: ''


### PR DESCRIPTION
*Issue #15225:*

*Description of changes:*

This PR reduces the time it takes for the Firebase remote config cache to be invalidated down to 1 minute, so that the application banner's message can be updated more frequently.