### PR TITLE
18647 Reset search filters when navigating to the search page

### DIFF
--- a/components/search/ResultsBox.vue
+++ b/components/search/ResultsBox.vue
@@ -230,6 +230,8 @@ function onDateDialogCancel() {
 
 // When the component is mounted, display initial values from the table
 onMounted(async () => {
+  search.resetFilters()
+  search.resetDisplayAndPage()
   await search.updateRows()
 })
 </script>

--- a/components/search/ResultsControl.vue
+++ b/components/search/ResultsControl.vue
@@ -3,7 +3,7 @@
     <a
       href="#"
       class="mr-4 font-semibold text-blue-800 transition duration-150 hover:text-blue-900"
-      @click="search.$reset()"
+      @click="reset"
       >{{ CLEAR_FILTERS_TEXT }}</a
     >
 
@@ -65,4 +65,9 @@ const DISPLAY_OPTIONS = [5, 10, 20, 50, 100]
 const pageOptions = computed(() =>
   Array.from({ length: search.lastPageNumber }, (_, key) => key + 1)
 )
+
+function reset() {
+  search.resetFilters()
+  search.resetDisplayAndPage()
+}
 </script>

--- a/store/search.ts
+++ b/store/search.ts
@@ -173,11 +173,23 @@ export const useSearchStore = defineStore('search', () => {
     }
   }
 
-  function $reset() {
+  function resetColumns() {
     selectedColumns.value = Object.values(SearchColumns)
+  }
+
+  function resetFilters() {
     Object.assign(filters, defaultFilters())
+  }
+
+  function resetDisplayAndPage() {
     selectedDisplay.value = DEFAULT_DISPLAY
     selectedPage.value = 1
+  }
+
+  function $reset() {
+    resetColumns()
+    resetFilters()
+    resetDisplayAndPage()
   }
 
   watch(
@@ -228,6 +240,9 @@ export const useSearchStore = defineStore('search', () => {
     toggleSubmittedDateOrder,
     goToPreviousPage,
     goToNextPage,
+    resetColumns,
+    resetFilters,
+    resetDisplayAndPage,
     $reset,
   }
 })

--- a/tests/component/SearchResultsControl.spec.ts
+++ b/tests/component/SearchResultsControl.spec.ts
@@ -26,7 +26,8 @@ describe('Search Page', () => {
     await wrapper
       .findWithText((wrapper.vm as any).CLEAR_FILTERS_TEXT)
       .trigger('click')
-    expect(search.$reset).toHaveBeenCalledOnce()
+    expect(search.resetFilters).toHaveBeenCalledOnce()
+    expect(search.resetDisplayAndPage).toHaveBeenCalledOnce()
   })
 
   it('sets the selected columns correctly when they are changed', async () => {


### PR DESCRIPTION
*Issue #18647:*

*Description of changes:*

This PR implements resetting the search filters in the search results box whenever the user navigates to the search page, including when they navigate away and then come back.