### PR TITLE
18182 - Name Examination UI - Upgrade nodejs version to 20.5.1

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "namex",
-  "version": "2.1.24",
+  "version": "2.1.25",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "namex",
-      "version": "2.1.24",
+      "version": "2.1.25",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
@@ -69,7 +69,7 @@
         "webpack-merge": "^5.2.0"
       },
       "engines": {
-        "node": ">= 16.0.0",
+        "node": ">= 20.0.0",
         "npm": ">= 8.0.0"
       }
     },

--- a/client/package.json
+++ b/client/package.json
@@ -1,9 +1,9 @@
 {
   "name": "namex",
-  "version": "2.1.24",
+  "version": "2.1.25",
   "description": "Webpack 5, Vue.js",
   "main": "main.js",
-  "author": "Per Olsen",
+  "author": "BC Public Services",
   "license": "MIT",
   "scripts": {
     "start": "webpack serve --config build/webpack.dev.conf.js --progress",
@@ -77,7 +77,7 @@
     "whatwg-fetch": "^3.6.2"
   },
   "engines": {
-    "node": ">= 16.0.0",
+    "node": ">= 20.0.0",
     "npm": ">= 8.0.0"
   },
   "browserslist": [


### PR DESCRIPTION
*Issue #: 18182 - Name Examination UI - Upgrade nodejs version to 20.5.1
https://github.com/bcgov/entity/issues/18182

