### PR TITLE
dockerfile

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:20.5.1 as build-stage
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY ./ .
+RUN npm run build
+
+FROM nginx:1.18.0 as production-stage
+
+ARG VCS_REF="missing"
+ARG BUILD_DATE="missing"
+
+ENV VCS_REF=${VCS_REF}
+ENV BUILD_DATE=${BUILD_DATE}
+
+LABEL org.label-schema.vcs-ref=${VCS_REF} \
+    org.label-schema.build-date=${BUILD_DATE}
+
+COPY nginx.conf /etc/nginx/nginx.conf
+RUN mkdir /app
+COPY --from=build-stage /app/dist /app
+EXPOSE 8080:8080
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
*Issue #:*

*Description of changes:* to upgrade to node 20, the base image in buildconfig needs to be updated. the image in namex-fe-build was for node 16. I added a dockerfile (similar to the one from filings-ui). I updated https://console.apps.silver.devops.gov.bc.ca/k8s/ns/f2b77c-tools/buildconfigs/namex-fe-build/yaml
To deploy we no longer need to build namex-web (as the 2 build steps are merged in the Dockerfile).



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0), i.e sink for namex-fe-build is namex-front, which is used directly in deploymnetconfig.

Looks like https://namex-dev.apps.silver.devops.gov.bc.ca/home is running fine.
