### PR TITLE
stick with 1 step

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -4,20 +4,3 @@ COPY package*.json ./
 RUN npm install
 COPY ./ .
 RUN npm run build
-
-FROM nginx:1.18.0 as production-stage
-
-ARG VCS_REF="missing"
-ARG BUILD_DATE="missing"
-
-ENV VCS_REF=${VCS_REF}
-ENV BUILD_DATE=${BUILD_DATE}
-
-LABEL org.label-schema.vcs-ref=${VCS_REF} \
-    org.label-schema.build-date=${BUILD_DATE}
-
-COPY nginx.conf /etc/nginx/nginx.conf
-RUN mkdir /app
-COPY --from=build-stage /app/dist /app
-EXPOSE 8080:8080
-CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
*Issue #:*

*Description of changes:* decided to build source code in a separate step, as currently caddy is configured to use old s2i-caddy image (https://github.com/BCDevOps/s2i-caddy) and it will take a bit of time to figure out how to setup new configurations (since we are moving to firebase for namex ui soon, maybe not efficient use of time).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
