### PR TITLE
#16316 fix a transaction/event display bug

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "namex",
-  "version": "2.1.25",
+  "version": "2.1.26",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "namex",
-      "version": "2.1.25",
+      "version": "2.1.26",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "namex",
-  "version": "2.1.25",
+  "version": "2.1.26",
   "description": "Webpack 5, Vue.js",
   "main": "main.js",
   "author": "BC Public Services",

--- a/client/src/components/application/Transactions.vue
+++ b/client/src/components/application/Transactions.vue
@@ -357,7 +357,7 @@
         if (nrInfo && nrInfo.stateCd) {
           displayState = nrInfo.stateCd
           if (displayState == 'CONDITIONAL') displayState += ' APPROVED'
-          else if (displayState == 'CONSUMED') {
+          else if (displayState == 'CONSUMED' && nrInfo.names && nrInfo.names.length > 0) {
             let approvedName = nrInfo.names.find(name => ['APPROVED', 'CONDITION'].includes(name.state))
             displayState = approvedName.state === 'CONDITION' ? 'CONDITIONAL APPROVED' : 'APPROVED'
             displayState += ` / Used for ${approvedName.corpNum}`


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/16316

*Description of changes:*
Some historical data may lack proper formatting, leading to missing names in event_json. If names are missing for the 'CONSUMED' action, it causes other events not to appear on the page. In such instances, we can simply ignore this information and display other transactions and events normally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
