### PR TITLE
19575 hotfix: the screen blank when clicking on Exmine Names

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "namex",
-  "version": "2.1.27",
+  "version": "2.1.28",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "namex",
-      "version": "2.1.27",
+      "version": "2.1.28",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "namex",
-  "version": "2.1.27",
+  "version": "2.1.28",
   "description": "Webpack 5, Vue.js",
   "main": "main.js",
   "author": "BC Public Services",

--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -51,6 +51,18 @@ let router = new Router({
       }
     },
     {
+      name: 'nameexamination-without-nrnumber',
+      component: NameExamination,
+      path: '/nameExamination',
+      meta: {
+        requiresAuth: true
+      },
+      beforeEnter: (to, from, next) => {
+        store.dispatch('getpostgrescompNo')
+        next()
+      }
+    },
+    {
       name: 'transactions',
       component: Transactions,
       path: '/transactions',


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/19575

*Description of changes:*
Name Examination Screen Blank when clicking on Examine Names tab

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
