### PR TITLE
Update "Consent Required" filter in search

### DIFF
--- a/enums/filter-dropdowns.ts
+++ b/enums/filter-dropdowns.ts
@@ -3,6 +3,7 @@ enum ConsentRequired {
   Yes = 'Yes',
   No = 'No',
   Received = 'Received',
+  Waived = 'Waived'
 }
 
 enum Priority {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "name-examination",
-  "version": "1.2.4",
+  "version": "1.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "name-examination",
-      "version": "1.2.4",
+      "version": "1.2.6",
       "hasInstallScript": true,
       "dependencies": {
         "@headlessui/vue": "0.0.0-insiders.01a34cb",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-examination",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "private": true,
   "scripts": {
     "build": "nuxt generate",

--- a/store/search.ts
+++ b/store/search.ts
@@ -13,6 +13,7 @@ import { getNamexObject, getNamexApiUrl } from '~/util/namex-api'
 import type { NameChoice } from '~/types'
 import { sortNameChoices } from '~/util'
 import { StatusSearchFilter, type Filters, type Row } from '~/types/search'
+import { ConsentFlag } from '~/enums/codes'
 
 export const defaultFilters = (): Filters => {
   return {
@@ -101,11 +102,13 @@ export const useSearchStore = defineStore('search', () => {
       [SearchColumns.NatureOfBusiness]:
         obj.natureBusinessInfo === null ? '' : obj.natureBusinessInfo,
       [SearchColumns.ConsentRequired]:
-        obj.consentFlag === 'R'
+        obj.consentFlag === ConsentFlag.Received
           ? 'Received'
-          : obj.consentFlag === 'Y'
-          ? 'Yes'
-          : 'No',
+          : obj.consentFlag === ConsentFlag.Required
+          ? 'Required'
+          : obj.consentFlag === ConsentFlag.Waived
+          ? 'Waived'
+          :'No',
       [SearchColumns.Priority]:
         obj.priorityCd === 'Y' ? 'Priority' : 'Standard',
       [SearchColumns.ClientNotification]:


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/20067

*Description of changes:*
update "Consent Required" filter in search.
Here are the meanings of the consent flags:
Null: No consent required.
R: Consent received.
N: Consent waived.
Y: Consent required.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
