### PR TITLE
set the last rejected name as current name choice

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "name-examination",
-  "version": "1.2.7",
+  "version": "1.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "name-examination",
-      "version": "1.2.7",
+      "version": "1.2.10",
       "hasInstallScript": true,
       "dependencies": {
         "@headlessui/vue": "0.0.0-insiders.01a34cb",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-examination",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "private": true,
   "scripts": {
     "build": "nuxt generate",

--- a/store/examine/index.ts
+++ b/store/examine/index.ts
@@ -462,14 +462,16 @@ export const useExamination = defineStore('examine', () => {
     )
 
     const newCurrentNameChoice = nameChoices.value
-      .filter(
-        (choice) =>
-          [Status.NotExamined, Status.Approved, Status.Condition].includes(
-            choice.state
-          ) && choice.name
-      )
-      .at(0)
-    setCurrentNameChoice(newCurrentNameChoice)
+      .filter(({ name, state }) => name && [Status.NotExamined, Status.Approved, Status.Condition].includes(state))[0]
+
+    if (newCurrentNameChoice) {
+      setCurrentNameChoice(newCurrentNameChoice)
+    } else {
+      const validNameChoices = nameChoices.value.filter(choice => choice.name)
+      if (validNameChoices.every(choice => choice.state === Status.Rejected)) {
+        currentNameObj.value = { ...validNameChoices[validNameChoices.length - 1] }
+      }
+    }
 
     nrStatus.value = info.state
     previousState.value = info.previousStateCd ?? undefined

--- a/store/examine/index.ts
+++ b/store/examine/index.ts
@@ -469,7 +469,7 @@ export const useExamination = defineStore('examine', () => {
     } else {
       const validNameChoices = nameChoices.value.filter(choice => choice.name)
       if (validNameChoices.every(choice => choice.state === Status.Rejected)) {
-        currentNameObj.value = { ...validNameChoices[validNameChoices.length - 1] }
+        currentNameObj.value = validNameChoices.at(-1)
       }
     }
 


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/20411

*Description of changes:*
Set the last rejected name as current name choice when reset a requests with all names have been rejected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
