### PR TITLE
Transactions page name list has incorrect order

### DIFF
--- a/components/examine/names_list/index.vue
+++ b/components/examine/names_list/index.vue
@@ -1,6 +1,6 @@
 <template>
   <ol class="list-decimal">
-    <li v-for="choice in choices">
+    <li v-for="choice in sortedChoices">
       <ExamineNamesListChoice
         :choice="choice"
         :decision-text="decisionReasonOrConflictList(choice)"
@@ -33,6 +33,8 @@ const props = defineProps<{
   /** Show '(DRAFT)' next to a name choice that has not been examined yet. */
   indicateDraft?: boolean
 }>()
+
+const sortedChoices = computed(() => props.choices.sort((a, b) => a.choice - b.choice))
 
 const isCurrent = (choice: number) => props.currentChoice === choice
 


### PR DESCRIPTION
*Issue #:* https://github.com/bcgov/entity/issues/20796

*Description of changes:* Name Examination UI - Transactions page name list has incorrect order


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
