### PR TITLE
Fix: Allow Accordion Text Selection and Copy in Exact Word Order + Synonym Match 

### DIFF
--- a/components/examine/recipe/conflicts/ListItem.vue
+++ b/components/examine/recipe/conflicts/ListItem.vue
@@ -2,7 +2,7 @@
   <Accordion
     :open="conflictItem.ui.open"
     ref="accordion"
-    class="rounded p-1 transition-all hover:bg-gray-100"
+    class="rounded p-1 transition-all hover:bg-gray-100 selectable"
     :class="{ '!bg-sky-100': conflictItem.ui.focused || conflictItem.ui.open }"
     @title-clicked="recipe.clickObject(conflictItem)"
   >
@@ -88,5 +88,9 @@ emitter.on('scrollToConflictObject', ({ obj, instant }) => {
 .synonym-stem-highlight {
   color: #e0a800;
   font-weight: bold;
+}
+
+.selectable {
+  user-select: text;
 }
 </style>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "name-examination",
-  "version": "1.2.16",
+  "version": "1.2.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "name-examination",
-      "version": "1.2.16",
+      "version": "1.2.17",
       "hasInstallScript": true,
       "dependencies": {
         "@headlessui/vue": "0.0.0-insiders.01a34cb",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-examination",
-  "version": "1.2.16",
+  "version": "1.2.17",
   "private": true,
   "scripts": {
     "build": "nuxt generate",


### PR DESCRIPTION
*Issue #:21000*

*Description of changes:*
Fixed the accordion text which was not drag selectable by setting `user-select: text` property in styles. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
