### PR TITLE
Changed date formation from UTC to ISO

### DIFF
--- a/store/examine/index.ts
+++ b/store/examine/index.ts
@@ -396,9 +396,7 @@ export const useExamination = defineStore('examine', () => {
       )
     }
     if (expiryDate.value) {
-      data.expirationDate = toFormattedDate(
-        parseDate(expiryDate.value).endOf('day')
-      )
+      data.expirationDate = parseDate(expiryDate.value).endOf('day').toISO()
     }
     if (submittedDate.value) {
       const submitDate = toFormattedDate(submittedDate.value)


### PR DESCRIPTION
*Issue #: 20887

*Description of changes:*
Since we use ISO while displaying transaction, I converted datetime format from UTC to ISO.
[This](https://github.com/bcgov/namex/pull/1533) PR contains the changes on the backend(namex) side.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
