### PR TITLE
Added Space Between Time and "AM/PM"

### DIFF
--- a/util/date.ts
+++ b/util/date.ts
@@ -1,6 +1,6 @@
 import { DateTime } from 'luxon'
 
-export const TIMESTAMP_FORMAT = 'yyyy-MM-dd, h:mma'
+export const TIMESTAMP_FORMAT = 'yyyy-MM-dd, h:mm a'
 
 /**
  * @param input An ISO-formatted date string


### PR DESCRIPTION
*Issue #: 20887*

*Description of changes:*
- Updated `/utils/date.ts/TIMESTAMP_FORMAT` to include space between time and "AM/PM".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
