### PR TITLE
For NRs in draft status that have not been edited. Made examiner name display as current examiner

### DIFF
--- a/components/examine/request_info/Status.vue
+++ b/components/examine/request_info/Status.vue
@@ -9,7 +9,7 @@
 
     <div class="flex items-center">
       <h2 class="font-bold">Examiner:&nbsp;</h2>
-      <p>{{ examine.examiner }}</p>
+      <p>{{ examinerStatus }}</p>
     </div>
 
     <ExamineRequestInfoCommentsPopup />
@@ -23,6 +23,7 @@ import { usePayments } from '~/store/examine/payments'
 
 const examine = useExamination()
 const payments = usePayments()
+const { $userProfile } = useNuxtApp()
 
 const additionalStatus = computed(() => {
   const approvedName = examine.nameChoices.find((name) =>
@@ -45,5 +46,10 @@ const additionalStatus = computed(() => {
   }
 
   return examine.nrStatus
+})
+
+const examinerStatus = computed(() => {
+  const notAssigned = examine.examiner === 'nro_service_account' || examine.examiner === '' || examine.examiner === 'name_request_service_account'
+  return notAssigned ? $userProfile.username : examine.examiner
 })
 </script>


### PR DESCRIPTION
…is instead the username of examiner logged in

*Issue #:*

*Description of changes:*
Made the examiner a computed property that displays the current examiner if it is one of the defaults. This change ensures that the examiner's name is shown only for display purposes and is not saved. This way, an examiner can view a ticket without editing it, keeping the ticket in 'open' status and allowing another examiner to claim it later with their own name.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
