### PR TITLE
remove the redundant code

### DIFF
--- a/components/examine/names_list/index.vue
+++ b/components/examine/names_list/index.vue
@@ -1,6 +1,6 @@
 <template>
   <ol class="list-decimal">
-    <li v-for="choice in choices">
+    <li v-for="choice in sortedChoices">
       <ExamineNamesListChoice
         :choice="choice"
         :decision-text="decisionReasonOrConflictList(choice)"
@@ -33,6 +33,8 @@ const props = defineProps<{
   /** Show '(DRAFT)' next to a name choice that has not been examined yet. */
   indicateDraft?: boolean
 }>()
+
+const sortedChoices = computed(() => props.choices.sort((a, b) => a.choice - b.choice))
 
 const isCurrent = (choice: number) => props.currentChoice === choice
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "name-examination",
-  "version": "1.2.16",
+  "version": "1.2.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "name-examination",
-      "version": "1.2.16",
+      "version": "1.2.17",
       "hasInstallScript": true,
       "dependencies": {
         "@headlessui/vue": "0.0.0-insiders.01a34cb",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "name-examination",
-  "version": "1.2.17",
+  "version": "1.2.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "name-examination",
-      "version": "1.2.17",
+      "version": "1.2.19",
       "hasInstallScript": true,
       "dependencies": {
         "@headlessui/vue": "0.0.0-insiders.01a34cb",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-examination",
-  "version": "1.2.16",
+  "version": "1.2.17",
   "private": true,
   "scripts": {
     "build": "nuxt generate",

--- a/store/examine/index.ts
+++ b/store/examine/index.ts
@@ -884,7 +884,6 @@ export const useExamination = defineStore('examine', () => {
   }
 
   async function updateNRState(state: Status) {
-    nrStatus.value = state
     await patchNameRequest(nrNumber.value, { state: state })
     await fetchAndLoadNr(nrNumber.value)
   }


### PR DESCRIPTION
*Issue #:*21593

*Description of changes:*
Removed nrStatus.value = state before the state is updated in the database. nrStatus is updated when retrieving NR information from the database.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
