### PR TITLE
20339 - implemented local storage to store dropdown filter status

### DIFF
--- a/components/search/ResultsBox.vue
+++ b/components/search/ResultsBox.vue
@@ -50,6 +50,7 @@
               :options="layout[column].dropdown"
               @change="
                 (option) => [
+                  setFilterStatus(column, option),
                   updateTextInputFilters(),
                   checkIfCustomSubmitDateChosen(option),
                 ]
@@ -230,6 +231,11 @@ function checkIfCustomSubmitDateChosen(option: any) {
   if (option == Submitted.Custom) {
     showDateDialog.value = true
   }
+}
+
+// Store filter status into local storage
+function setFilterStatus(column: string, option: string) {
+  window.localStorage.setItem(column, option);
 }
 
 function onDateDialogSubmit(startDate: string, endDate: string) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "name-examination",
-  "version": "1.2.18",
+  "version": "1.2.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "name-examination",
-      "version": "1.2.18",
+      "version": "1.2.19",
       "hasInstallScript": true,
       "dependencies": {
         "@headlessui/vue": "0.0.0-insiders.01a34cb",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "name-examination",
-  "version": "1.2.17",
+  "version": "1.2.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "name-examination",
-      "version": "1.2.17",
+      "version": "1.2.18",
       "hasInstallScript": true,
       "dependencies": {
         "@headlessui/vue": "0.0.0-insiders.01a34cb",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-examination",
-  "version": "1.2.18",
+  "version": "1.2.19",
   "private": true,
   "scripts": {
     "build": "nuxt generate",

--- a/store/search.ts
+++ b/store/search.ts
@@ -16,18 +16,22 @@ import { StatusSearchFilter, type Filters, type Row } from '~/types/search'
 import { ConsentFlag } from '~/enums/codes'
 
 export const defaultFilters = (): Filters => {
+  const getFilterValue = <T>(key: string, defaultValue: T): T => {
+    return (window.localStorage.getItem(key) as T) || defaultValue;
+  };
+  
   return {
-    [SearchColumns.Status]: StatusSearchFilter.Hold,
+    [SearchColumns.Status]: getFilterValue(SearchColumns.Status, StatusSearchFilter.Hold),
     [SearchColumns.LastModifiedBy]: '',
     [SearchColumns.NameRequestNumber]: '',
     [SearchColumns.Names]: '',
     [SearchColumns.ApplicantFirstName]: '',
     [SearchColumns.ApplicantLastName]: '',
-    [SearchColumns.ConsentRequired]: ConsentRequired.All,
-    [SearchColumns.Priority]: Priority.All,
-    [SearchColumns.ClientNotification]: ClientNotification.All,
-    [SearchColumns.Submitted]: Submitted.All,
-    [SearchColumns.LastUpdate]: LastUpdate.All,
+    [SearchColumns.ConsentRequired]: getFilterValue(SearchColumns.ConsentRequired, ConsentRequired.All),
+    [SearchColumns.Priority]: getFilterValue(SearchColumns.Priority, Priority.All),
+    [SearchColumns.ClientNotification]: getFilterValue(SearchColumns.ClientNotification, ClientNotification.All),
+    [SearchColumns.Submitted]: getFilterValue(SearchColumns.Submitted, Submitted.All),
+    [SearchColumns.LastUpdate]: getFilterValue(SearchColumns.LastUpdate, LastUpdate.All),
   }
 }
 


### PR DESCRIPTION
*Issue #: [20339](https://app.zenhub.com/workspaces/names-team-board-new-655554cbddd49510027dad2e/issues/gh/bcgov/entity/20339)

*Description of changes:*
Implemented Local Storage to persist dropdown filter status.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
