### PR TITLE
Changed url to not be mandatory. Trying to get Cypress Github action smoke tests to work

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,7 +8,7 @@ on:
         description: 'Is this a smoke test?'
         default: 'true'
       url_parameter:
-        required: true
+        required: false
         description: 'Which URL to test?'
       logLevel:
         description: 'Log level'


### PR DESCRIPTION
*Issue #:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
