### PR TITLE
remove the redundant code when updating nr state to inprogress

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "name-examination",
-      "version": "1.2.19",
+      "version": "1.2.20",
       "hasInstallScript": true,
       "dependencies": {
         "@headlessui/vue": "0.0.0-insiders.01a34cb",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "name-examination",
-  "version": "1.2.19",
+  "version": "1.2.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-examination",
-  "version": "1.2.19",
+  "version": "1.2.20",
   "private": true,
   "scripts": {
     "build": "nuxt generate",

--- a/app/store/examine/index.ts
+++ b/app/store/examine/index.ts
@@ -882,7 +882,6 @@ export const useExamination = defineStore('examine', () => {
   }
 
   async function updateNRState(state: Status) {
-    nrStatus.value = state
     await patchNameRequest(nrNumber.value, { state: state })
     await fetchAndLoadNr(nrNumber.value)
   }


### PR DESCRIPTION
remove the redundant code when updating nr state from draft to inprogress

*Issue #:*
[21593](https://github.com/bcgov/entity/issues/21593)

*Description of changes:*
NR states updated twice when UpdateNRState, which causing screen flash. Removed one.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
