### PR TITLE
20999 - Auto Add Fix: Make Initial Conflicts List Immutable

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "name-examination",
-  "version": "1.2.20",
+  "version": "1.2.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "name-examination",
-      "version": "1.2.20",
+      "version": "1.2.21",
       "hasInstallScript": true,
       "dependencies": {
         "@headlessui/vue": "0.0.0-insiders.01a34cb",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-examination",
-  "version": "1.2.20",
+  "version": "1.2.21",
   "private": true,
   "scripts": {
     "build": "nuxt generate",

--- a/app/store/examine/conflicts.ts
+++ b/app/store/examine/conflicts.ts
@@ -339,9 +339,12 @@ export const useConflicts = defineStore('conflicts', () => {
   /** Reset selectedConflicts and comparedConflicts and save existing data */
   function disableAutoAdd () {
     if (!autoAdd.value) {
+      const initialRun = (prevSelectedConflicts.value.length === 0 && prevComparedConflicts.value.length === 0)
       for (const conflict of selectedConflicts.value) {
-        prevSelectedConflicts.value.push(conflict)
-        prevComparedConflicts.value.push(conflict)
+        if (initialRun) {
+          prevSelectedConflicts.value.push(conflict)
+          prevComparedConflicts.value.push(conflict)
+        }
         const notConflict = (c: ConflictListItem) =>
           c.nrNumber !== conflict.nrNumber
         selectedConflicts.value = selectedConflicts.value.filter(notConflict)
@@ -355,8 +358,6 @@ export const useConflicts = defineStore('conflicts', () => {
     if (autoAdd.value) {
       selectedConflicts.value = prevSelectedConflicts.value
       comparedConflicts.value = prevComparedConflicts.value
-      prevSelectedConflicts.value = []
-      prevComparedConflicts.value = []
     }
   }
 


### PR DESCRIPTION
*Issue #:* https://github.com/bcgov/entity/issues/20999

*Description of changes:*
With [Initial PR](https://github.com/bcgov/name-examination/pull/1477), users were able to modify the automatically selected conflict lists with `auto add` checked on and this would persists. With these changes, the automatically selected conflict lists would remain immutable but users can uncheck `auto add` and then make their selections.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
