### PR TITLE
22015 displaying wrong examiner name

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-examination",
-  "version": "1.2.23",
+  "version": "1.2.24",
   "private": true,
   "scripts": {
     "build": "nuxt generate",

--- a/app/store/transactions.ts
+++ b/app/store/transactions.ts
@@ -94,6 +94,22 @@ export const useTransactions = defineStore('transactions', () => {
       : 'Not required'
   }
 
+  async function getLatestIdir(nrNumber: string) {
+    try {
+      await loadNr(nrNumber)
+      await loadTransactions(nrNumber)
+
+      const latestIdirEntry = transactions.value
+        .filter(entry => entry.user_name.includes('idir'))
+        .sort((a, b) => new Date(b.eventDate).getTime() - new Date(a.eventDate).getTime())
+        [0]
+
+      return latestIdirEntry ? latestIdirEntry.user_name : 'N/A'
+    } catch (error) {
+      return 'N/A'
+    }
+  }
+
   return {
     nr,
     transactions,
@@ -103,5 +119,6 @@ export const useTransactions = defineStore('transactions', () => {
     getStatusDisplay,
     getRequestTypeDisplay,
     getConsentDisplay,
+    getLatestIdir
   }
 })


### PR DESCRIPTION
*Issue #:* https://app.zenhub.com/workspaces/names-team-board-new-655554cbddd49510027dad2e/issues/gh/bcgov/entity/22015

*Description of changes:*
  - Made it so when examining an NR. If the examiner field is not an IDIR it searches for the last IDIR username in transactions table. If an IDIR is not found it keeps the examiner field as is, else updates the examiner field. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
