### PR TITLE
22308 fix priority queue toggle

### DIFF
--- a/app/components/app_header/index.vue
+++ b/app/components/app_header/index.vue
@@ -52,8 +52,8 @@
           <ToggleSwitch
             label="Priority Queue"
             data-testid="prioritySwitch"
-            @click="togglePriorityQueue"
-            v-model="priorityQueue"
+            :modelValue="queueToggleVal"
+            @update:modelValue="togglePriorityQueue"
           />
         </div>
 
@@ -77,8 +77,7 @@
 import { Route } from '~/enums/routes'
 import { useExamination } from '~/store/examine'
 import { emitter } from '~/util/emitter'
-import { KeyOfPriorityQueue } from '~/util/constants';
-import { getLocalStorageValue } from '~/util';
+import { useExaminationOptions } from '~/store/examine/options'
 
 const { $auth, $userProfile } = useNuxtApp()
 
@@ -88,7 +87,10 @@ const adminURL = config.public.namexAdminURL
 const examine = useExamination()
 
 const searchText = ref('')
-const priorityQueue = ref(true)
+
+const examineOptions = useExaminationOptions()
+const { priorityQueue, updatePriority } = examineOptions
+const queueToggleVal = ref(priorityQueue)
 
 /** Parse the input as an NR number, tries to return a string in the form 'NR x' where 'x' is a number. */
 function parseNrNumber(input: string) {
@@ -112,11 +114,8 @@ async function onSearchSubmit(_: Event) {
   }
 }
 
-function togglePriorityQueue() {
-  window.localStorage.setItem(KeyOfPriorityQueue, String(priorityQueue.value))
+function togglePriorityQueue(newValue: boolean) {
+  queueToggleVal.value = newValue
+  updatePriority(newValue)
 }
-
-onMounted(() => {
-  priorityQueue.value = getLocalStorageValue(KeyOfPriorityQueue, 'true') === 'true'
-})
 </script>

--- a/app/enums/filter-dropdowns.ts
+++ b/app/enums/filter-dropdowns.ts
@@ -39,10 +39,28 @@ enum LastUpdate {
   Days30 = '30 days'
 }
 
+enum FilterKey {
+  ConsentRequired = 'consentRequired',
+  Priority = 'priority',
+  ClientNotification = 'clientNotification',
+  Submitted = 'submitted',
+  LastUpdate = 'lastUpdate',
+}
+
+const filterTypeMap = {
+  [FilterKey.ConsentRequired]: ConsentRequired.All,
+  [FilterKey.Priority]: Priority.All,
+  [FilterKey.ClientNotification]: ClientNotification.All,
+  [FilterKey.Submitted]: Submitted.All,
+  [FilterKey.LastUpdate]: LastUpdate.All,
+}
+
 export {
   ConsentRequired,
   Priority,
   ClientNotification,
   Submitted,
   LastUpdate,
+  FilterKey,
+  filterTypeMap
 }

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-examination",
-  "version": "1.2.23",
+  "version": "1.2.24",
   "private": true,
   "scripts": {
     "build": "nuxt generate",

--- a/app/store/examine/options.ts
+++ b/app/store/examine/options.ts
@@ -1,6 +1,13 @@
 import { defineStore } from 'pinia'
+import { getLocalStorageValue } from '~/util'
 
 export const useExaminationOptions = defineStore('examine-options', () => {
-  const priorityQueue = ref(true)
-  return { priorityQueue }
+  const priorityQueue = ref(getLocalStorageValue('PriorityQueue', false))
+
+  const updatePriority = (newPriority: boolean) => {
+    priorityQueue.value = newPriority
+    window.localStorage.setItem('PriorityQueue', JSON.stringify(newPriority))
+  }
+
+  return { priorityQueue, updatePriority }
 })

--- a/app/store/search.ts
+++ b/app/store/search.ts
@@ -7,6 +7,8 @@ import {
   LastUpdate,
   Priority,
   Submitted,
+  FilterKey,
+  filterTypeMap
 } from '~/enums/filter-dropdowns'
 import { getFormattedDateWithTime } from '~/util/date'
 import { getNamexObject, getNamexApiUrl } from '~/util/namex-api'
@@ -23,11 +25,11 @@ export const defaultFilters = (): Filters => {
     [SearchColumns.Names]: '',
     [SearchColumns.ApplicantFirstName]: '',
     [SearchColumns.ApplicantLastName]: '',
-    [SearchColumns.ConsentRequired]: getLocalStorageValue(SearchColumns.ConsentRequired, ConsentRequired.All),
-    [SearchColumns.Priority]: getLocalStorageValue(SearchColumns.Priority, Priority.All),
-    [SearchColumns.ClientNotification]: getLocalStorageValue(SearchColumns.ClientNotification, ClientNotification.All),
-    [SearchColumns.Submitted]: getLocalStorageValue(SearchColumns.Submitted, Submitted.All),
-    [SearchColumns.LastUpdate]: getLocalStorageValue(SearchColumns.LastUpdate, LastUpdate.All),
+    [SearchColumns.ConsentRequired]: getLocalStorageValue(SearchColumns.ConsentRequired, filterTypeMap[FilterKey.ConsentRequired]),
+    [SearchColumns.Priority]: getLocalStorageValue(SearchColumns.Priority, filterTypeMap[FilterKey.Priority]),
+    [SearchColumns.ClientNotification]: getLocalStorageValue(SearchColumns.ClientNotification, filterTypeMap[FilterKey.ClientNotification]),
+    [SearchColumns.Submitted]: getLocalStorageValue(SearchColumns.Submitted, filterTypeMap[FilterKey.Submitted]),
+    [SearchColumns.LastUpdate]: getLocalStorageValue(SearchColumns.LastUpdate, filterTypeMap[FilterKey.LastUpdate]),
   }
 }
 

--- a/app/util/constants.ts
+++ b/app/util/constants.ts
@@ -5,5 +5,3 @@ export enum SessionStorageKeys {
 export enum FeatureFlags {
   NAMEX_BANNER = 'namex_banner',
 }
-
-export const KeyOfPriorityQueue = 'PriorityQueue'

--- a/app/util/index.ts
+++ b/app/util/index.ts
@@ -149,9 +149,16 @@ export const getLocalStorageValue = <T>(key: string, defaultValue: T): T => {
     return defaultValue
   }
   try {
-    return JSON.parse(storedValue) as T
+    // Try to parse as JSON first
+    const item = JSON.parse(storedValue) as T
+    return item
   } catch (error) {
-    window.localStorage.setItem(key, JSON.stringify(defaultValue))
-    return defaultValue
+    // If parsing fails and the type is string, return the stored value directly
+    if (typeof defaultValue === 'string') {
+      return storedValue as unknown as T
+    } else {
+      window.localStorage.setItem(key, JSON.stringify(defaultValue))
+      return defaultValue
+    }
   }
 }

--- a/app/util/index.ts
+++ b/app/util/index.ts
@@ -143,5 +143,15 @@ export function clamp(value: number, min: number, max: number): number {
 
 /** Get `value` from local storage using `key` */
 export const getLocalStorageValue = <T>(key: string, defaultValue: T): T => {
-  return (window.localStorage.getItem(key) as T) || defaultValue;
-};
+  const storedValue = window.localStorage.getItem(key)
+  if (storedValue === null) {
+    window.localStorage.setItem(key, JSON.stringify(defaultValue))
+    return defaultValue
+  }
+  try {
+    return JSON.parse(storedValue) as T
+  } catch (error) {
+    window.localStorage.setItem(key, JSON.stringify(defaultValue))
+    return defaultValue
+  }
+}


### PR DESCRIPTION
*Issue #:* 22308
https://app.zenhub.com/workspaces/names-team-board-new-655554cbddd49510027dad2e/issues/gh/bcgov/entity/22308

*Description of changes:*
Integrated storing and retrieving variables from local storage with the Vue Store better. Previously it was only using local storage but the request used the Vue Store, meaning when queue was toggled requests still came in with the queue set as true. 

To do this some types had to be defined to properly retrieve the value from storage as the correct type. Also the other dropdowns had to be slightly modified.


**The queue toggle will only work in Test and Prod**
- For some reason the queue does not work in dev, currently it never picks up NRs of priority while test always picks up NRs of priority. This means it will have to be tested in test only.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
