### PR TITLE
21893 Catch errors when updating NR data

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-examination",
-  "version": "1.2.30",
+  "version": "1.2.31",
   "private": true,
   "scripts": {
     "build": "nuxt generate",

--- a/app/store/examine/index.ts
+++ b/app/store/examine/index.ts
@@ -817,7 +817,6 @@ export const useExamination = defineStore('examine', () => {
     // set reset flag so name data is managed between Namex and NRO correctly
     hasBeenReset.value = true
     await updateRequest()
-    await fetchAndLoadNr(nrNumber.value)
   }
 
   async function resetNr() {
@@ -825,7 +824,6 @@ export const useExamination = defineStore('examine', () => {
     clearConsent()
     furnished.value = 'N'
     await updateRequest()
-    await fetchAndLoadNr(nrNumber.value)
   }
 
   async function claimNr() {
@@ -900,15 +898,18 @@ export const useExamination = defineStore('examine', () => {
   }
 
   async function updateRequest() {
-    const data = await getNrData()
-    const response = await putNameRequest(nrNumber.value, data)
-    if (response.ok) {
+    try {
+      const data = await getNrData()
+      const response = await putNameRequest(nrNumber.value, data)
+      if (!response.ok) {
+        throw new Error('Failed to update NR')
+      }
       await parseNr(await response.json())
-    } else {
-      emitter.emit('error', {
-        title: `Failed to update NR`,
-        message: `An error occurred while trying to update ${nrNumber.value}`,
-      })
+    } catch {
+        emitter.emit('error', {
+          title: `Failed to update NR`,
+          message: `An error occurred while trying to update ${nrNumber.value}`,
+        })
       await fetchAndLoadNr(nrNumber.value)
     }
   }


### PR DESCRIPTION
Issue #: https://app.zenhub.com/workspaces/names-team-board-new-655554cbddd49510027dad2e/issues/gh/bcgov/entity/21893

Description of changes:
 - Added a try-catch block to the update function.
 - Removed unnecessary fetchAndLoadNr() calls as that method is already called in updateRequest()

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).