### PR TITLE
19608 calls COLIN-API from LEAR instead of NAMEX

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "name-examination",
-  "version": "1.2.24",
+  "version": "1.2.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "name-examination",
-      "version": "1.2.24",
+      "version": "1.2.32",
       "hasInstallScript": true,
       "dependencies": {
         "@headlessui/vue": "0.0.0-insiders.01a34cb",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-examination",
-  "version": "1.2.31",
+  "version": "1.2.32",
   "private": true,
   "scripts": {
     "build": "nuxt generate",

--- a/app/util/index.ts
+++ b/app/util/index.ts
@@ -46,11 +46,8 @@ export async function corpExists(input: string) {
   const corpNum = input.replace(/^BC+/i, '')
   const corporationResponse = await getCorporation(corpNum)
   if (corporationResponse.ok) {
-    const responseJson = await corporationResponse.json()
-    return !(
-      responseJson.incorporated === 'Not Available' &&
-      responseJson.directors === 'Not Available'
-    )
+    // the corporation exists
+    return true
   } else if (corporationResponse.status === 404) {
     return false
   } else {

--- a/app/util/namex-api.ts
+++ b/app/util/namex-api.ts
@@ -177,7 +177,7 @@ export async function getNextNrNumber(isPriority: boolean) {
 }
 
 export async function getCorporation(corpNum: string) {
-  return callNamexApi(getNamexApiUrl(`/corporations/${corpNum}`))
+  return callNamexApi(getNamexApiUrl(`/colin/${corpNum}`))
 }
 
 export async function getPayments(id: number) {


### PR DESCRIPTION
*Issue #:*
[19608](https://github.com/bcgov/entity/issues/19608)
https://github.com/bcgov/entity/issues/22809

*Description of changes:*
Per the changes in 19608, the COLIN-API call will be updated from the old NameX COLIN_API to the service located in namex/colin, which aligns with the implementation in NameRequest.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
