### PR TITLE
22417 fix flakey smoke tests

### DIFF
--- a/app/components/PriorityLabel.vue
+++ b/app/components/PriorityLabel.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex items-center font-bold text-red-600">
     <StarIcon :class="iconStyle ?? 'h-4 w-4'" />
-    <p>Priority</p>
+    <p data-testid="priorityLabel">Priority</p>
   </div>
 </template>
 

--- a/app/components/app_header/index.vue
+++ b/app/components/app_header/index.vue
@@ -5,7 +5,7 @@
   >
   <div class="flex h-full w-full items-center justify-between">
       <div class="hidden h-full lg:block">
-        <nuxt-link :to="Route.Home">
+        <nuxt-link :to="Route.Home" data-testid="homeLink">
           <img
             src="/images/top-nav.png"
             class="min-w-8 h-full"

--- a/app/components/examine/decision/Header.vue
+++ b/app/components/examine/decision/Header.vue
@@ -8,6 +8,7 @@
         class="h-4 w-4"
         type="checkbox"
         v-model="examine.consentRequired"
+        data-testid="consentCheckbox"
       />
       <span>Consent</span>
     </label>

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-examination",
-  "version": "1.2.32",
+  "version": "1.2.33",
   "private": true,
   "scripts": {
     "build": "nuxt generate",

--- a/testing/cypress/constants.ts
+++ b/testing/cypress/constants.ts
@@ -4,6 +4,7 @@ export const NRState = {
   Approved: 'APPROVED',
   Hold: 'HOLD',
   InProgress: 'INPROGRESS',
+  Conditional: 'CONDITIONAL',
 }
 
 export const SearchFilter = {
@@ -17,4 +18,5 @@ export const SearchFilter = {
 export const DecisionText = {
   RejectDist: 'Require distinctive, nondescriptive first word or prefix * E.G. Person\'s name, initials, geographic location, etc.',
   RejectDesc: 'Require descriptive second word or phrase * E.G. Construction, Gardening, Investments, Holdings, Etc.',
+  ApproveConditionalConsent: 'Consent Required',
 }

--- a/testing/cypress/e2e/smoke/smoke-20-approvals.cy.ts
+++ b/testing/cypress/e2e/smoke/smoke-20-approvals.cy.ts
@@ -1,9 +1,10 @@
 // Cypress Test: Check for ability to approve NRs.
 // This spec checks that NRs can be approved with the approval button and quick approval button.
+// This spec also checks that NRs can be conditionally approved.
 import HomePage from 'cypress/pageObjects/homePage'
 import SearchPage from 'cypress/pageObjects/searchPage'
 import ExaminePage from 'cypress/pageObjects/examinePage'
-import { NRState } from 'cypress/constants'
+import { NRState, DecisionText } from 'cypress/constants'
 const homePage = new HomePage()
 const searchPage = new SearchPage()
 const examinePage = new ExaminePage()
@@ -56,6 +57,30 @@ describe('Check that approving NRs works', () => {
     cy.get(examinePage.choice1CheckMark).should('be.visible')
     cy.get('@nrNum').then((nrNum) => {
       cy.verifyNRState(nrNum.toString(), NRState.Approved)
+    })
+  })
+
+
+  it('Should be able to conditionally approve a NR', () => {
+    // Get the first NR from the Examine Names button.
+    homePage.examineNamesLink()
+    examinePage.retrieveCurrentNr()
+    cy.get(examinePage.nrStatus).should('have.text', NRState.InProgress)
+
+    // Activate the consent required checkbox and then approve the name.
+    examinePage.toggleConsentCheckbox(true)
+    examinePage.clickApproveButton()
+
+    // Verify conditional approval on examine page.
+    cy.get(examinePage.nrStatus).should('have.text', NRState.Conditional)
+    cy.get(examinePage.choice1DecisionTxt)
+      .invoke('text')
+      .then((text) => text.trim())
+      .should('eq', DecisionText.ApproveConditionalConsent)
+
+    // Verify conditional approval on search page.
+    cy.get('@nrNum').then((nrNum) => {
+      cy.verifyNRState(nrNum.toString(), NRState.Conditional)
     })
   })
 })

--- a/testing/cypress/e2e/smoke/smoke-60-priorityqueue.cy.ts
+++ b/testing/cypress/e2e/smoke/smoke-60-priorityqueue.cy.ts
@@ -1,0 +1,78 @@
+// Cypress Test: Check for ability of priority queue to work as expected.
+// This spec checks that the priority queue properly grabs NRs of the correct
+// priority from both the Examine Names button and the Get Next button.
+import HomePage from 'cypress/pageObjects/homePage'
+import ExaminePage from 'cypress/pageObjects/examinePage'
+import { NRState } from 'cypress/constants'
+const homePage = new HomePage()
+const examinePage = new ExaminePage()
+
+describe('Check that the priority queue works', () => {
+  beforeEach(() => {
+    cy.cleanGC()
+    cy.setid('default')
+    cy.login()
+  })
+
+  afterEach(() => {
+    cy.logout()
+  })
+
+  it('should correctly select a priority or non-priority NR using the examine names button', () => {
+    // Examine a nmae in case there is alreay one in progress
+    homePage.examineNamesLink()
+    cy.get(examinePage.nrStatus).should('have.text', NRState.InProgress)
+    examinePage.clickHoldButton()
+    cy.get(examinePage.nrStatus).should('have.text', NRState.Hold)
+
+    // Go back to the home page
+    homePage.homeLink()
+
+    // Turn the priority queue off, fetch NR using examine names button, and verify
+    homePage.setPrioritySwitch(false)
+    homePage.examineNamesLink()
+    cy.get(examinePage.nrStatus).should('have.text', NRState.InProgress)
+    cy.get(examinePage.priorityLabel).should('not.exist')
+    examinePage.clickHoldButton()
+    cy.get(examinePage.nrStatus).should('have.text', NRState.Hold)
+
+    // Go back to the home page
+    homePage.homeLink()
+
+    // Turn the priority queue on, fetch NR using the examine names button, and verify
+    homePage.setPrioritySwitch(true)
+    homePage.examineNamesLink()
+    cy.get(examinePage.nrStatus).should('have.text', NRState.InProgress)
+    cy.get(examinePage.priorityLabel).should('be.visible')
+    examinePage.clickHoldButton()
+    cy.get(examinePage.nrStatus).should('have.text', NRState.Hold)
+  })
+
+  it('should correctly select a priority or non-priority NR using the get next button', () => {
+    // Examine a nmae in case there is alreay one in progress
+    homePage.examineNamesLink()
+    cy.get(examinePage.nrStatus).should('have.text', NRState.InProgress)
+    examinePage.clickHoldButton()
+    cy.get(examinePage.nrStatus).should('have.text', NRState.Hold)
+
+    // Test with priority queue off
+    homePage.setPrioritySwitch(false)
+    for (let i = 0; i < 2; i++) {
+      examinePage.clickNextButton()
+      cy.get(examinePage.nrStatus).should('have.text', NRState.InProgress)
+      cy.get(examinePage.priorityLabel).should('not.exist')
+      examinePage.clickHoldButton()
+      cy.get(examinePage.nrStatus).should('have.text', NRState.Hold)
+    }
+
+    // Test with priority queue on
+    homePage.setPrioritySwitch(true)
+    for (let i = 0; i < 2; i++) {
+      examinePage.clickNextButton()
+      cy.get(examinePage.nrStatus).should('have.text', NRState.InProgress)
+      cy.get(examinePage.priorityLabel).should('be.visible')
+      examinePage.clickHoldButton()
+      cy.get(examinePage.nrStatus).should('have.text', NRState.Hold)
+    }
+  })
+})

--- a/testing/cypress/pageObjects/examinePage.ts
+++ b/testing/cypress/pageObjects/examinePage.ts
@@ -192,9 +192,9 @@ class ExaminePage {
    * and then waits until the page is stable.
    */
   clickRejectButton() {
-    cy.intercept('PATCH', '**/api/v1/requests/NR*').as('quickRejectPatchRequest')
+    cy.intercept('PUT', '**/api/v1/requests/NR*/names/*').as('rejectPutRequest')
     cy.get(this.primaryRejectBtn).should('be.visible').click({ force: true })
-    cy.wait('@quickRejectPatchRequest').its('response.statusCode').should('eq', 200)
+    cy.wait('@rejectPutRequest').its('response.statusCode').should('eq', 200)
     cy.wait(1000)
   }
 
@@ -203,9 +203,9 @@ class ExaminePage {
    * and then waits until the page is stable.
    */
   clickQuickRejectDistButton() {
-    cy.intercept('PATCH', '**/api/v1/requests/NR*').as('quickRejectDistPatchRequest')
+    cy.intercept('PUT', '**/api/v1/requests/NR*/names/*').as('rejectDistPutRequest')
     cy.get(this.quickRejectDistBtn).click({ force: true })
-    cy.wait('@quickRejectDistPatchRequest').its('response.statusCode').should('eq', 200)
+    cy.wait('@rejectDistPutRequest').its('response.statusCode').should('eq', 200)
     cy.wait(1000)
   }
 
@@ -214,9 +214,9 @@ class ExaminePage {
    * and then waits until the page is stable.
    */
   clickQuickRejectDescButton() {
-    cy.intercept('PATCH', '**/api/v1/requests/NR*').as('quickRejectDescPatchRequest')
+    cy.intercept('PUT', '**/api/v1/requests/NR*/names/*').as('rejectDescPutRequest')
     cy.get(this.quickRejectDescBtn).click({ force: true })
-    cy.wait('@quickRejectDescPatchRequest').its('response.statusCode').should('eq', 200)
+    cy.wait('@rejectDescPutRequest').its('response.statusCode').should('eq', 200)
     cy.wait(1000)
   }
 

--- a/testing/cypress/pageObjects/examinePage.ts
+++ b/testing/cypress/pageObjects/examinePage.ts
@@ -11,6 +11,7 @@ class ExaminePage {
   // Header and transactions link
   nrNumberHeader = 'div[data-testid="nrNumberHeader"]'
   openTransactionsLink = 'a[data-testid="openTransactionsLink"]'
+  priorityLabel = 'p[data-testid="priorityLabel"]'
 
   // Action butttons
   actionNextBtn = 'button[data-testid="actionNextBtn"]'
@@ -72,6 +73,9 @@ class ExaminePage {
   // Comments
   commentsPopupBtn = 'button[data-testid="commentsPopupBtn"]'
   commentsContainer = 'div[data-testid="commentsContainer"]'
+
+  // Decision Information
+  consentCheckbox = 'input[data-testid="consentCheckbox"]'
 
   /******** Editing ********/
 
@@ -264,6 +268,18 @@ class ExaminePage {
     cy.get(showDetails ? this.actionHideDetailsBtn : this.actionShowDetailsBtn)
       .should('be.visible')
     cy.wait(1000)
+  }
+
+  /**
+  * Toggles the consent checkbox on or off.
+  * @param shouldCheck - If true, the checkbox will be checked; if false, it will be unchecked.
+  */
+  toggleConsentCheckbox(shouldCheck: boolean) {
+    cy.get(this.consentCheckbox).then($checkbox => {
+      if ($checkbox.is(':checked') !== shouldCheck) {
+        cy.wrap($checkbox).click()
+      }
+    })
   }
 }
 

--- a/testing/cypress/pageObjects/homePage.ts
+++ b/testing/cypress/pageObjects/homePage.ts
@@ -12,6 +12,7 @@ class HomePage {
   popupPanel = 'div[data-testid="popupPanel"]'
 
   // Top Level Links
+  homeLinkID = 'a[data-testid="homeLink"]'
   adminLinkID = 'a[data-testid="adminLink"]'
   examineLinkID = 'a[data-testid="examineLink"]'
   searchLinkID = 'a[data-testid="searchLink"]'
@@ -47,6 +48,16 @@ class HomePage {
         cy.log($text)
       })
     }
+
+  /**
+   * Navigates to the home page by clicking the NameX Icon in the header.
+   */
+  homeLink() {
+    cy.intercept('GET', '**/api/v1/requests*').as('homeLinkRequest')
+    cy.get(this.homeLinkID).should('be.visible').click( { force: true } )
+    cy.wait('@homeLinkRequest').its('response.statusCode').should('eq', 200)
+    cy.url().should('eq', Cypress.config().baseUrl + '/')
+  }
 
   /**
    * Navigates to the admin page by clicking the "Admin" link.


### PR DESCRIPTION
*Issue #:*
Relates to https://app.zenhub.com/workspaces/names-team-board-new-655554cbddd49510027dad2e/issues/gh/bcgov/entity/22417

The rejections test was flakey based on number of names per NR so needed to be fixed.

*Description of changes:*
- Changed rejections to assert PUT requests instead of PATCH requests
- Added a test for conditional approval
- Added tests for the priority queue


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
