### PR TITLE
23752 namex version not picked up correctly

### DIFF
--- a/app/components/app_footer/VersionInfo.vue
+++ b/app/components/app_footer/VersionInfo.vue
@@ -38,23 +38,19 @@ onMounted(async () => {
 })
 
 const fetchNameXVersion = async (): Promise<string> => {
-  const devNameXVersionEndpoint = 'https://namex-dev.apps.silver.devops.gov.bc.ca/api/v1/meta/info'
-  // const testNameXVersionEndpoint = 'https://namex-test.apps.silver.devops.gov.bc.ca/api/v1/meta/info'
-  // const prodNameXVersionEndpoint = 'https://namex.apps.silver.devops.gov.bc.ca/api/v1/meta/info'
+  const baseUrl = process.env.NUXT_NAMEX_API_URL || 'https://namex-dev.apps.silver.devops.gov.bc.ca'
+  const versionPath = process.env.NUXT_NAMEX_API_VERSION || '/api/v1'
+  const versionEndpoint = `${baseUrl}${versionPath}/meta/info`
 
   try {
-    const response = await fetch(devNameXVersionEndpoint)
-    if (!response.ok) {
-      console.error('Failed to fetch:', response.status, response.statusText)
-      throw Error
-    }
-    const responseJson = await response.json()
-    const fullVersion = responseJson.API.split('/')[1]
-    const version = fullVersion.match(/^(\d+\.\d+\.\d+)/)?.[0] || 'Unknown'
+    const response = await fetch(versionEndpoint)
+    if (!response.ok) throw new Error(`Fetch failed: ${response.statusText}`)
 
-    return version
+    const { API } = await response.json()
+    return API.match(/\d+\.\d+\.\d+/)?.[0] || 'Unknown'
+
   } catch (error) {
-    console.error('Error fetching data:', error)
+    console.error('Error fetching NameX API version:', error)
     return 'Error'
   }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-examination",
-  "version": "1.2.33",
+  "version": "1.2.34",
   "private": true,
   "scripts": {
     "build": "nuxt generate",

--- a/testing/cypress/appActions/Utilities.ts
+++ b/testing/cypress/appActions/Utilities.ts
@@ -47,22 +47,12 @@ class Utilities {
   }
 
   /**
-   * Returns the current date in the format "YYYYMMDD".
+   * Returns the current date in the format "YYYY-MM-DD".
    *
-   * @return The current date in the format "YYYYMMDD".
+   * @return The current date in the format "YYYY-MM-DD".
    */
   getDate(): string {
-    const today = new Date()
-    let dd: any = today.getDate()
-    let mm: any = today.getMonth() + 1 // January is 0!
-    const yyyy = today.getFullYear()
-    if (dd < 10) {
-      dd = '0' + dd
-    }
-    if (mm < 10) {
-      mm = '0' + mm
-    }
-    return yyyy + mm + dd
+    return new Date().toLocaleDateString('en-CA')
   }
 
   /**

--- a/testing/cypress/pageObjects/homePage.ts
+++ b/testing/cypress/pageObjects/homePage.ts
@@ -40,11 +40,7 @@ class HomePage {
       .invoke('text')
       .then(($text) => {
         const date = util.getDate()
-        const formattedDate = `${date.substring(0, 4)}-${date.substring(
-          4,
-          6
-        )}-${date.substring(6, 8)}`
-        expect($text).to.contain(formattedDate)
+        expect($text.trim()).to.include(date)
         cy.log($text)
       })
     }


### PR DESCRIPTION
*Issue #:*

*Description of changes:*
- Fixed how the UI gets the API version number. Instead of always getting the version number of dev api it gets the version number of whatever API it is pointing at. 
- Also corrected the check for the current date on the home page for the E2E cypress testing. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
