### PR TITLE
22784_fix_401_response_on_nr_approvals

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-examination",
-  "version": "1.2.35",
+  "version": "1.2.36",
   "private": true,
   "scripts": {
     "build": "nuxt generate",

--- a/app/store/examine/index.ts
+++ b/app/store/examine/index.ts
@@ -483,13 +483,6 @@ export const useExamination = defineStore('examine', () => {
       consentDate.value = getDateFromDateTime(parsedConsentDate) ?? undefined
     }
 
-    // if the current state is not INPROGRESS, HOLD, or DRAFT clear any existing name record in currentNameObj
-    if (
-      ![Status.InProgress, Status.Hold, Status.Draft].includes(nrStatus.value)
-    ) {
-      setCurrentNameChoice(undefined)
-    }
-
     // we keep the original data so that if fields exist that we do not use, we don't lose that
     // data when we put new data
     clientFirstName.value = info.applicants.clientFirstName ?? undefined

--- a/testing/cypress/pageObjects/examinePage.ts
+++ b/testing/cypress/pageObjects/examinePage.ts
@@ -176,7 +176,7 @@ class ExaminePage {
   clickApproveButton() {
     cy.intercept('PATCH', '**/api/v1/requests/NR*').as('approvePatchRequest')
     cy.get(this.primaryApproveBtn).should('be.visible').click({ force: true })
-    cy.wait('@approvePatchRequest') // TO_DO: This button is returning a 401
+    cy.wait('@approvePatchRequest').its('response.statusCode').should('eq', 200)
     cy.wait(1000)
   }
 
@@ -187,7 +187,7 @@ class ExaminePage {
   clickQuickApproveButton() {
     cy.intercept('PATCH', '**/api/v1/requests/NR*').as('quickApprovePatchRequest')
     cy.get(this.quickApproveBtn).should('be.visible').click({ force: true })
-    cy.wait('@quickApprovePatchRequest') // TO_DO: This button is returning a 401
+    cy.wait('@quickApprovePatchRequest').its('response.statusCode').should('eq', 200)
     cy.wait(1000)
   }
 


### PR DESCRIPTION
*Issue #:* https://app.zenhub.com/workspaces/names-team-board-new-655554cbddd49510027dad2e/issues/gh/bcgov/entity/22784

*Description of changes:*
**Problem**: When a Name Request (NR) is approved, an unnecessary second patch request is sent, leading to a 401 error. This happens because the `currentNameChoice` is incorrectly set to undefined during the approval process.

**Solution**: Removed the code that sets the `currentNameChoice` to undefined from the `parseNr` method in the Examine Store. 

**Detailed Explanation** 
 - Upon NR approval via `makeDecision(APPROVED)`, the `pushDecision(APPROVED)` and subsequently `updateNRState(APPROVED)` are triggered. [Code Reference](https://github.com/bcgov/name-examination/blob/main/app/store/examine/index.ts#L632)
 - This sequence leads to `fetchAndLoadNr(nrNum)` and then to `parseNr()`, where currentNameChoice was being set to undefined. [Code Reference](https://github.com/bcgov/name-examination/blob/main/app/store/examine/index.ts#L490)
 - With `currentNameChoice` undefined, the system incorrectly attempts to process a Next Name Choice, resulting in an unauthorized patch request. [Code Reference](https://github.com/bcgov/name-examination/blob/main/app/store/examine/index.ts#L653)
 - There seems to be no reason why the `currentNameChoice` gets set to undefined in `parseNr`. The application still has full functionality without that code. 
 
**Update E2E Tests for the fixed functionality.**
- Instead of waiting for the approval request to finish, the tests for approvals now ensure the response has a status code of 200. 



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
