### PR TITLE
#24298 Ensure no errors occur even when conflict corp information is empty.

### DIFF
--- a/app/components/examine/recipe/match/BCCorp.vue
+++ b/app/components/examine/recipe/match/BCCorp.vue
@@ -5,11 +5,11 @@
       <p>BC Corporation</p>
 
       <h3 class="font-bold">Corp Number</h3>
-      <p>{{ data['incorp #'] }}</p>
+      <p>{{ data['identifier'] }}</p>
 
       <h3 class="font-bold">Directors</h3>
       <div class="flex flex-col">
-        <p v-if="data.directors === 'Not Available'">Not Available</p>
+        <p v-if="!data?.directors?.length">Not Available</p>
         <p v-else v-for="director in data.directors">{{ director }}</p>
       </div>
 
@@ -20,7 +20,7 @@
     <div class="grid basis-1/2 grid-cols-2 overflow-x-auto">
       <h3 class="font-bold">Records Office Delivery Address</h3>
       <div>
-        <p v-if="data['records office delivery address'] === 'Not Available'">
+        <p v-if="!data?.['records office delivery address']?.length">
           Not Available
         </p>
         <p
@@ -34,7 +34,7 @@
       </div>
 
       <h3 class="font-bold">Registered Office Delivery Address</h3>
-      <div>
+      <div v-if="data['registered office delivery address']">
         <p
           v-for="addrLine in parseAddress(
             data['registered office delivery address']

--- a/app/components/examine/recipe/match/XproCorp.vue
+++ b/app/components/examine/recipe/match/XproCorp.vue
@@ -5,11 +5,11 @@
       <p>XPRO Corporation</p>
 
       <h3 class="font-bold">Corp Number</h3>
-      <p>{{ conflict['incorp #'] }}</p>
+      <p>{{ conflict['identifier'] }}</p>
 
       <h3 class="font-bold">Attorneys</h3>
       <div class="flex flex-col">
-        <p v-if="isNotAvailable(conflict['attorney names'])">Not available</p>
+        <p v-if="!conflict?.['attorney names']?.length">Not available</p>
         <p v-else v-for="attorney in conflict['attorney names']">
           {{ attorney }}
         </p>
@@ -22,12 +22,12 @@
     <div class="grid basis-1/2 grid-cols-2 overflow-x-auto">
       <h3 class="font-bold">Directors</h3>
       <div class="flex flex-col">
-        <p v-if="isNotAvailable(conflict.directors)">Not available</p>
+        <p v-if="!conflict?.directors?.length">Not available</p>
         <p v-else v-for="director in conflict.directors">{{ director }}</p>
       </div>
 
       <h3 class="font-bold">Head Office</h3>
-      <div>
+      <div v-if="conflict['head office']" >
         <p v-for="addrLine in parseAddress(conflict['head office'])">
           {{ addrLine }}
         </p>

--- a/app/components/examine/recipe/match/index.vue
+++ b/app/components/examine/recipe/match/index.vue
@@ -4,7 +4,7 @@
   </div>
   <div v-else-if="conflictData">
     <ExamineRecipeMatchNames
-      v-if="conflict.source === 'NR' || conflict.source === 'NRO'"
+      v-if="conflict.source === 'NR' || conflict.source === 'NRO' || conflict.source === 'NAMEREQUEST'"
       :conflict="(conflictData as NameRequest)"
     />
     <ExamineRecipeMatchBCCorp

--- a/app/components/examine/recipe/match/index.vue
+++ b/app/components/examine/recipe/match/index.vue
@@ -4,15 +4,15 @@
   </div>
   <div v-else-if="conflictData">
     <ExamineRecipeMatchNames
-      v-if="conflict.source === ConflictSource.NameRequest || conflict.source === ConflictSource.NRO"
+      v-if="conflict.source === 'NAMEREQUEST' || conflict.source === 'NRO'"
       :conflict="(conflictData as NameRequest)"
     />
     <ExamineRecipeMatchBCCorp
-      v-else-if="conflict.source === ConflictSource.Corp && (conflictData as Corporation).jurisdiction === 'BC'"
+      v-else-if="conflict.source === 'CORP' && (conflictData as Corporation).jurisdiction === 'BC'"
       :data="(conflictData as BCCorporation)"
     />
     <ExamineRecipeMatchXproCorp
-      v-else-if="conflict.source === ConflictSource.Corp && (conflictData as Corporation).jurisdiction !== 'BC'"
+      v-else-if="conflict.source === 'CORP' && (conflictData as Corporation).jurisdiction !== 'BC'"
       :conflict="(conflictData as XproCorporation)"
     />
     <div v-else>Failed to determine conflict info type</div>

--- a/app/components/examine/recipe/match/index.vue
+++ b/app/components/examine/recipe/match/index.vue
@@ -4,15 +4,15 @@
   </div>
   <div v-else-if="conflictData">
     <ExamineRecipeMatchNames
-      v-if="conflict.source === 'NR' || conflict.source === 'NRO' || conflict.source === 'NAMEREQUEST'"
+      v-if="conflict.source === ConflictSource.NameRequest || conflict.source === ConflictSource.NRO"
       :conflict="(conflictData as NameRequest)"
     />
     <ExamineRecipeMatchBCCorp
-      v-else-if="conflict.source === 'CORP' && (conflictData as Corporation).jurisdiction === 'BC'"
+      v-else-if="conflict.source === ConflictSource.Corp && (conflictData as Corporation).jurisdiction === 'BC'"
       :data="(conflictData as BCCorporation)"
     />
     <ExamineRecipeMatchXproCorp
-      v-else-if="conflict.source === 'CORP' && (conflictData as Corporation).jurisdiction !== 'BC'"
+      v-else-if="conflict.source === ConflictSource.Corp && (conflictData as Corporation).jurisdiction !== 'BC'"
       :conflict="(conflictData as XproCorporation)"
     />
     <div v-else>Failed to determine conflict info type</div>

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-examination",
-  "version": "1.2.34",
+  "version": "1.2.35",
   "private": true,
   "scripts": {
     "build": "nuxt generate",

--- a/app/store/examine/conflict-data.ts
+++ b/app/store/examine/conflict-data.ts
@@ -5,10 +5,15 @@ import {
   type Corporation,
   type NameRequest,
 } from '~/types'
-import { getCorporation, getNameRequest } from '~/util/namex-api'
+import { getBusiness, getCorporation, getNameRequest } from '~/util/namex-api'
 
 export const useConflictData = defineStore('conflict-data', () => {
   async function getCorpConflict(corpNum: string): Promise<Corporation> {
+    // search for businsess in BCRS
+    const businessResponse = await getBusiness(corpNum)
+    if (businessResponse.ok) return businessResponse.json()
+    
+    // search for business in COLIN
     const response = await getCorporation(corpNum)
     return response.json()
   }

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -75,7 +75,7 @@ export interface Histories {
 
 export enum ConflictSource {
   Corp = 'CORP',
-  NameRequest = 'NR',
+  NameRequest = 'NAMEREQUEST',
   NRO = 'NRO',
 }
 

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -34,19 +34,19 @@ export interface Comment {
 export type ConflictData = NameRequest | Corporation
 
 export interface Corporation {
-  'incorp #': string
-  directors: string[] | 'Not Available'
+  'identifier': string
+  directors: string[]
   'nature of business': string
   jurisdiction: string
 }
 
 export interface BCCorporation extends Corporation {
-  'records office delivery address': string[] | 'Not Available'
+  'records office delivery address': string[]
   'registered office delivery address': string[]
 }
 
 export interface XproCorporation extends Corporation {
-  'attorney names': string[] | 'Not Available'
+  'attorney names': string[]
   'head office': string[]
 }
 


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/24298

*Description of changes:*
Ensure no errors occur even when conflict corp information is empty

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
