### PR TITLE
#24298 Name-Examination UI - error occurred when selecting conflict or conflict selection has values

### DIFF
--- a/app/store/examine/conflict-data.ts
+++ b/app/store/examine/conflict-data.ts
@@ -9,6 +9,11 @@ import { getCorporation, getNameRequest } from '~/util/namex-api'
 
 export const useConflictData = defineStore('conflict-data', () => {
   async function getCorpConflict(corpNum: string): Promise<Corporation> {
+    // Currently, the corp number is in the Colin format, so there's no need to search in BCROS.
+    //const businessResponse = await getBusiness(corpNum)
+    //if (businessResponse.ok) return businessResponse.json()
+    
+    // search for business in COLIN
     const response = await getCorporation(corpNum)
     return response.json()
   }


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/24298

*Description of changes:*
This is an update to the previous code change: the section for retrieving conflict business info from Entities has been commented out because:
1. The corp number from Solr query result is in the COLIN format (without the BC prefix).
2. The business query does not provide office and party information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
