### PR TITLE
23752 use runtime config when fetching namex version

### DIFF
--- a/app/components/app_footer/VersionInfo.vue
+++ b/app/components/app_footer/VersionInfo.vue
@@ -38,8 +38,9 @@ onMounted(async () => {
 })
 
 const fetchNameXVersion = async (): Promise<string> => {
-  const baseUrl = process.env.NUXT_NAMEX_API_URL || 'https://namex-dev.apps.silver.devops.gov.bc.ca'
-  const versionPath = process.env.NUXT_NAMEX_API_VERSION || '/api/v1'
+  const config = useRuntimeConfig()
+  const baseUrl = config.public.namexAPIURL || ''
+  const versionPath = config.public.namexAPIVersion || ''
   const versionEndpoint = `${baseUrl}${versionPath}/meta/info`
 
   try {

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-examination",
-  "version": "1.2.36",
+  "version": "1.2.37",
   "private": true,
   "scripts": {
     "build": "nuxt generate",


### PR DESCRIPTION
*Issue #:* https://app.zenhub.com/workspaces/names-team-board-new-655554cbddd49510027dad2e/issues/gh/bcgov/entity/23752

*Description of changes:*
Nuxt3 does not expose environment variables directly for security reasons which was causing this method to fail and default to the dev configuration. 

This PR makes use of the runtime config to get these environment variables instead that are defined here:
https://github.com/bcgov/name-examination/blob/main/app/nuxt.config.ts#L43

Also this PR gets rid of the default values so when it does not work it is obvious and does not potentially give the 'wrong version'.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
