### PR TITLE
21053 entity type codes for new societies set to null

### DIFF
--- a/app/data/request_types.json
+++ b/app/data/request_types.json
@@ -292,7 +292,9 @@
     "class_type_cd": "CORP",
     "legacy_cd": "SO",
     "additional_info": "",
-    "source_application": ""
+    "source_application": "",
+    "entity_type_cd": "SO",
+    "request_action_cd": "NEW"
   },
   {
     "value": "ASO",
@@ -301,7 +303,9 @@
     "class_type_cd": "CORP",
     "legacy_cd": "SO",
     "additional_info": "Amalgamation",
-    "source_application": ""
+    "source_application": "",
+    "entity_type_cd": "SO",
+    "request_action_cd": "AML"
   },
   {
     "value": "CSO",
@@ -310,7 +314,9 @@
     "class_type_cd": "CORP",
     "legacy_cd": "SO",
     "additional_info": "Change of Name",
-    "source_application": ""
+    "source_application": "",
+    "entity_type_cd": "SO",
+    "request_action_cd": "CHG"
   },
   {
     "value": "RSO",
@@ -319,7 +325,9 @@
     "class_type_cd": "CORP",
     "legacy_cd": "SO",
     "additional_info": "Restoration",
-    "source_application": ""
+    "source_application": "",
+    "entity_type_cd": "SO",
+    "request_action_cd": "REH"
   },
   {
     "value": "CTSO",
@@ -328,7 +336,9 @@
     "class_type_cd": "CORP",
     "legacy_cd": "SO",
     "additional_info": "Continuation In",
-    "source_application": ""
+    "source_application": "",
+    "entity_type_cd": "SO",
+    "request_action_cd": "MVE"
   },
   {
     "value": "XSO",
@@ -337,7 +347,9 @@
     "class_type_cd": "CORP",
     "legacy_cd": "SO",
     "additional_info": "",
-    "source_application": ""
+    "source_application": "",
+    "entity_type_cd": "SO",
+    "request_action_cd": "NEW"
   },
   {
     "value": "XCSO",
@@ -346,7 +358,9 @@
     "class_type_cd": "CORP",
     "legacy_cd": "SO",
     "additional_info": "Change of Name",
-    "source_application": ""
+    "source_application": "",
+    "entity_type_cd": "SO",
+    "request_action_cd": "CHG"
   },
   {
     "value": "XRSO",
@@ -355,7 +369,9 @@
     "class_type_cd": "CORP",
     "legacy_cd": "SO",
     "additional_info": "Restoration",
-    "source_application": ""
+    "source_application": "",
+    "entity_type_cd": "SO",
+    "request_action_cd": "REH"
   },
   {
     "value": "XASO",
@@ -364,7 +380,9 @@
     "class_type_cd": "CORP",
     "legacy_cd": "AS",
     "additional_info": "",
-    "source_application": ""
+    "source_application": "",
+    "entity_type_cd": "SO",
+    "request_action_cd": "ASSUMED"
   },
   {
     "value": "XCASO",
@@ -373,7 +391,9 @@
     "class_type_cd": "CORP",
     "legacy_cd": "AS",
     "additional_info": "",
-    "source_application": ""
+    "source_application": "",
+    "entity_type_cd": "SO",
+    "request_action_cd": "CHG"
   },
   {
     "value": "CSSO",
@@ -382,7 +402,9 @@
     "class_type_cd": "CORP",
     "legacy_cd": "SO",
     "additional_info": "Conversion",
-    "source_application": ""
+    "source_application": "",
+    "entity_type_cd": "SO",
+    "request_action_cd": "CHG"
   },
   {
     "value": "CP",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-examination",
-  "version": "1.2.37",
+  "version": "1.2.38",
   "private": true,
   "scripts": {
     "build": "nuxt generate",


### PR DESCRIPTION
*Issue #:* https://app.zenhub.com/workspaces/names-team-board-new-655554cbddd49510027dad2e/issues/gh/bcgov/entity/21053

*Description of changes:*
When a new Society is created they correctly have the Entity Type Code and Request Action Code in NameX DB. 

The problem occurs (entity type code set to null) when the NR is updated in Name-Examination UI. 
- The `updateRequest()` fires which calls `getNrData()` which updates the `entity_type_code` based on the `requestTypeObject`
https://github.com/bcgov/name-examination/blob/main/app/store/examine/index.ts#L371
- The problem is that the `requestTypeObject` for Societies do not have this `entity_type_cd` so it becomes null on the UI which updates the database to also be null

This PR adds the missing entity_type_cd for all societies. It also adds the missing request_action_cd as that is also becoming null in this process. 



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
