### PR TITLE
26228 bump version number to 1.2.40

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-examination",
-  "version": "1.2.39",
+  "version": "1.2.40",
   "private": true,
   "scripts": {
     "build": "nuxt generate",


### PR DESCRIPTION
*Description of changes:*
Version Number was not bumped in https://github.com/bcgov/name-examination/pull/1560 (Keycloak Upgrade fix PR)
- This PR bumps the version number so 1.2.40 can be released to prod instead of releasing 1.2.39 on top of 1.2.39

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
