### PR TITLE
26816-Conditions are not being populated in Message to Requestor Field

### DIFF
--- a/app/components/examine/decision/RequestorMessage.vue
+++ b/app/components/examine/decision/RequestorMessage.vue
@@ -31,6 +31,7 @@
       hide-submit
       hide-cancel
       :character-limit="characterLimit"
+      :key="key"
     />
     <span
       v-if="examine.requestorMessage.length > characterLimit"
@@ -66,7 +67,18 @@
 import { useExamination } from '~/store/examine'
 import { BackspaceIcon, PencilSquareIcon } from '@heroicons/vue/24/outline'
 
+let key = ref(0)
 const examine = useExamination()
+
+// we need this work-around to make the text box update its output
+// whenever Requestor Message changes; for some reason, it's not
+// reacting normally
+watch(
+    () => [examine.requestorMessage],
+    async (_state) => {
+      key.value++
+    }
+  )
 
 const characterLimit = 955
 const characterLimitDisplay = `Message cut off at ${characterLimit} characters`

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-examination",
-  "version": "1.2.40",
+  "version": "1.2.41",
   "private": true,
   "scripts": {
     "build": "nuxt generate",


### PR DESCRIPTION
*Issue #:*

*Description of changes:*  Fixed the issue that the selected items from Conditions, Conflicts, Macros, or Trademarks are not pop up on the "Message To Requestor" box.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
