### PR TITLE
26502 calls to namex api include app-name header

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,104 +3,17 @@ name: NAME-EXAMINATION UI CI
 on:
   pull_request:
     types: [assigned, synchronize]
+  workflow_dispatch:
 
 defaults:
   run:
     shell: bash
+    working-directory: ./
 
 jobs:
-  setup-job:
-    runs-on: ubuntu-24.04.1
-
-    if: github.repository == 'bcgov/name-examination'
-
-    steps:
-      - uses: actions/checkout@v3
-      - run: 'true'
-
-  linting:
-    needs: setup-job
-    runs-on: ubuntu-20.04
-
-    strategy:
-      matrix:
-        node-version: [20.5.1]
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-version }}
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 8
-      - name: Install dependencies
-        working-directory: ./app
-        run: |
-          npm install
-      - name: Linting
-        working-directory: ./app
-        run: |
-          npm run lint
-
-  testing-coverage:
-    needs: setup-job
-    runs-on: ubuntu-20.04
-
-    strategy:
-      matrix:
-        node-version: [20.5.1]
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-version }}
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 8
-      - name: Install dependencies
-        working-directory: ./app
-        run: |
-          npm install
-      - name: Testing
-        working-directory: ./app
-        id: test
-        run: |
-          npm run coverage
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          flags: name-examination-ui
-          name: codecov-namex
-          fail_ci_if_error: true
-          token: c4c60cf0-440a-4527-bdb8-0ae8b51c62bf
-
-  build-check:
-    needs: setup-job
-    runs-on: ubuntu-20.04
-
-    strategy:
-      matrix:
-        node-version: [20.5.1]
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-version }}
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 8
-      - name: Install dependencies
-        working-directory: ./app
-        run: |
-          npm install
-      - name: build
-        working-directory: ./app
-        id: build
-        run: |
-          npm run build
+  nameexamination-ci:
+    uses: bcgov/bcregistry-sre/.github/workflows/frontend-ci.yaml@main
+    with:
+      app_name: "nameexamination"
+      working_directory: "./app"
+      codecov_flag: ""

--- a/app/components/app_footer/VersionInfo.vue
+++ b/app/components/app_footer/VersionInfo.vue
@@ -27,6 +27,7 @@
 <script setup lang="ts">
 import packageInfo from '~/package.json'
 import { ref, onMounted } from 'vue'
+import { getNamexApiVersion } from '~/util/namex-api'
 
 const showVersionNumbers = ref(false)
 const nameExaminationVersion = ref('')
@@ -38,13 +39,8 @@ onMounted(async () => {
 })
 
 const fetchNameXVersion = async (): Promise<string> => {
-  const config = useRuntimeConfig()
-  const baseUrl = config.public.namexAPIURL || ''
-  const versionPath = config.public.namexAPIVersion || ''
-  const versionEndpoint = `${baseUrl}${versionPath}/meta/info`
-
   try {
-    const response = await fetch(versionEndpoint)
+    const response = await getNamexApiVersion()
     if (!response.ok) throw new Error(`Fetch failed: ${response.statusText}`)
 
     const { API } = await response.json()

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-examination",
-  "version": "1.2.42",
+  "version": "1.2.43",
   "private": true,
   "scripts": {
     "build": "nuxt generate",

--- a/app/util/namex-api.ts
+++ b/app/util/namex-api.ts
@@ -1,4 +1,5 @@
 import type { NameChoice, NameRequest, Transactions } from '~/types'
+import packageInfo from '~/package.json'
 
 /**
  * Retrieve the Keycloak session token, refreshing to make it valid if necessary.
@@ -27,6 +28,7 @@ async function callNamexApi(url: URL, options?: object, headers?: object) {
   return fetch(url, {
     headers: {
       Authorization: `Bearer ${token}`,
+      'App-Name': packageInfo.name,
       ...headers,
     },
     ...(options ? options : {}),
@@ -186,4 +188,8 @@ export async function getPayments(id: number) {
 
 export async function getStats(params: URLSearchParams) {
   return callNamexApi(getNamexApiUrl('/requests/stats?' + params))
+}
+
+export async function getNamexApiVersion() {
+  return callNamexApi(getNamexApiUrl('/meta/info'))
 }


### PR DESCRIPTION
*Issue #: https://github.com/bcgov/entity/issues/26502

*Description of changes:*
Calls to NameX API include app-name header. 
- All calls to NameX API go through the `callNamexApi` method. So the app-name was added here which was retrieved from the package.json file
- There was a call to NameX API to get the version number that did not go through `callNamexApi`, so that was changed to make it so that it does for consistency.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
