### PR TITLE
29880 Retrieve history data from get conflicts query

### DIFF
--- a/app/store/examine/conflicts.ts
+++ b/app/store/examine/conflicts.ts
@@ -1,6 +1,6 @@
 import type { ConflictListItem } from '~/types'
 import { getConflicts } from '~/util/namex-api'
-import { useExaminationRecipe } from './recipe'
+
 
 export const useConflicts = defineStore('conflicts', () => {
   const exactMatches = ref<Array<ConflictListItem>>([])
@@ -37,13 +37,14 @@ export const useConflicts = defineStore('conflicts', () => {
     }
   }
 
-  async function retrieveConflicts(query: string): Promise<[ConflictListItem[], ConflictListItem[]]> {
+  async function retrieveConflicts(query: string): Promise<[ConflictListItem[], ConflictListItem[], any[]]> {
     const resp = await getConflicts(query)
     if (!resp.ok) throw new Error('Unable to retrieve exact matches')
     const json = await resp.json()
     const exactMatches = parseExactMatches(json?.exactNames || [])
     const similarMatches = parseSynonymMatches(json?.names || [])
-    return [exactMatches, similarMatches]
+    const histories = json?.histories
+    return [exactMatches, similarMatches, histories]
   }
 
   function parseExactMatches(exactMatches: Array<any>): Array<ConflictListItem> {
@@ -95,10 +96,10 @@ export const useConflicts = defineStore('conflicts', () => {
     loading.value = true
     resetConflictLists()
     try {
-      const [exact, synonym] = await retrieveConflicts(searchQuery)
+      const [exact, synonym, histories] = await retrieveConflicts(searchQuery)
       exactMatches.value = exact
       synonymMatches.value = synonym
-      useExaminationRecipe().reset()
+      return histories
     } catch (e) {
       resetMatches()
       throw e

--- a/app/store/examine/index.ts
+++ b/app/store/examine/index.ts
@@ -860,6 +860,20 @@ export const useExamination = defineStore('examine', () => {
     return response.ok ? await response.json() : []
   }
 
+  function parseHistoryMatches(historyMatches: Array<any>): Array<HistoryEntry> {
+    return historyMatches.map((match) => {
+      return {
+          name: match.name,
+          jurisdiction: match.parent_jurisdiction,
+          nr_num: match.parent_id,
+          start_date: match.parent_start_date,
+          name_state_type_cd: match.parent_type,
+          score: match.score ?? 0,
+          submit_count: match.submit_count ?? 0
+      }
+    })
+  }
+
   function parseConditions(data: ConditionsList): Array<Condition> {
     const conditions = []
     for (const word of data.restricted_words_conditions) {
@@ -996,12 +1010,13 @@ export const useExamination = defineStore('examine', () => {
       errors.push(e as Error)
     }
     try {
-      await conflicts.initialize(searchQuery, exactPhrase)
+      const results = await conflicts.initialize(searchQuery, exactPhrase)
+      histories.value = parseHistoryMatches(results)
     } catch (e) {
       errors.push(e as Error)
     }
     if (errors.length > 0) {
-      const message = errors.join('\n')
+      const message = errors.map(e => e.message).join('\n')
       throw new Error(message)
     }
   }


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/29880

*Description of changes:*
Retrieve history data from get conflicts query

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
