### PR TITLE
32819-CLIENTS REPORTING THEIR EXPIRY TIMES ARE INCORRECT

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-examination",
-  "version": "1.2.48",
+  "version": "1.2.49",
   "private": true,
   "scripts": {
     "build": "nuxt generate",

--- a/app/store/examine/index.ts
+++ b/app/store/examine/index.ts
@@ -34,7 +34,7 @@ import {
 import { getEmptyNameChoice, isValidNrFormat, sortNameChoices } from '~/util'
 import { DateTime } from 'luxon'
 import { fromMappedRequestType, toMappedRequestType } from '~/util/request-type'
-import { getDateFromDateTime, parseDate } from '~/util/date'
+import { getDateFromDateTime, parseDate, utcToPSTIso } from '~/util/date'
 import { useConflicts } from './conflicts'
 import { usePayments } from './payments'
 import { useExaminationOptions } from './options'
@@ -512,7 +512,7 @@ export const useExamination = defineStore('examine', () => {
     priority.value = info.priorityCd === 'Y'
 
     expiryDate.value = info.expirationDate
-      ? getDateFromDateTime(parseDate(info.expirationDate)) ?? undefined
+      ? utcToPSTIso(info.expirationDate).slice(0, 10) ?? undefined
       : undefined
 
     submittedDate.value = parseDate(info.submittedDate)

--- a/app/util/date.ts
+++ b/app/util/date.ts
@@ -48,3 +48,14 @@ export function getFormattedDateWithTimeAndZone(input: DateTime): string {
 export function parseDate(input: string) {
   return DateTime.fromISO(input)
 }
+
+/** Parse a date string into a `luxon` `DateTime` object.
+ * @param input A date string from a NameX API object (ISO format)
+ */
+export function utcToPSTIso (utcString: string): string {
+  const utcDate = new Date(utcString)
+
+  // subtract 8 hours (in ms)
+  const pstTime = new Date(utcDate.getTime() - 8 * 60 * 60 * 1000)
+  return pstTime.toISOString().replace('Z', '-08:00')
+}


### PR DESCRIPTION
*Issue #:* 32819

*Description of changes:*
URGENT: CLIENTS REPORTING THEIR EXPIRY TIMES ARE AT 12:59AM THE NEXT DAY #32819

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
