### PR TITLE
fix: reorder conflict results to phonetic,synonym,character swap

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-examination",
-  "version": "1.2.49",
+  "version": "1.2.50",
   "private": true,
   "scripts": {
     "build": "nuxt generate",

--- a/app/store/examine/conflicts.ts
+++ b/app/store/examine/conflicts.ts
@@ -26,9 +26,9 @@ export const useConflicts = defineStore('conflicts', () => {
   /** Flattened array of every `ConflictList` across all buckets. */
   const lists = computed<Array<ConflictList>>(() =>
     [
+      phoneticMatches.value,
       synonymMatches.value,
       cobrsPhoneticMatches.value,
-      phoneticMatches.value,
     ].flat()
   )
 


### PR DESCRIPTION
https://github.com/bcgov/entity/issues/32482

Summary
Corrects the display order of conflict result buckets in the name examiner UI. The buckets were rendering in the wrong priority sequence

Problem
The conflict results panel was rendering in this order:

Exact Match
Exact Word Order + Synonym Match ← wrong position
Character Swap Match ← wrong position
Phonetic Match ← wrong position


Fix
Reordered the lists  in app/store/examine/conflicts.ts to match the intended priority in the ticket.

Exact Match
Phonetic Match 
Exact Word Order + Synonym Match
Proximity Search
Exact word order
Proximity search
Exact word order (based on word stubs)
Character Swap Match (COBRS phonetic)


Change
app/store/examine/conflicts.ts


// Before
synonymMatches.value,
cobrsPhoneticMatches.value,
phoneticMatches.value,

// After
phoneticMatches.value,
synonymMatches.value,
cobrsPhoneticMatches.value,


Testing
Verified in TEST environment using NR 1351427 (SMITH INC.):

<img width="734" height="286" alt="current-UI-NAMEX-SORT-ORDER-B4-FIX" src="https://github.com/user-attachments/assets/b7c9b5b7-09d4-480e-99e0-d23996d888f1" />


Bucket	numFound
Exact Match	0
Phonetic Match	35
Exact Word Order + Synonym Match	348 + 85
Character Swap Match	11