### PR TITLE
fix: split conflict results into 4 priority buckets (Exact, Phonetic,…

### DIFF
--- a/app/components/examine/recipe/conflicts/index.vue
+++ b/app/components/examine/recipe/conflicts/index.vue
@@ -20,8 +20,18 @@
       />
 
       <ExamineRecipeConflictsBucket
-        title="Possible Conflicts"
+        title="Phonetic Match (experimental)"
+        :conflict-items="conflicts.phoneticMatches"
+      />
+
+      <ExamineRecipeConflictsBucket
+        title="Exact Word Order + Synonym Match"
         :conflict-items="conflicts.synonymMatches"
+      />
+
+      <ExamineRecipeConflictsBucket
+        title="Character Swap Match"
+        :conflict-items="conflicts.cobrsPhoneticMatches"
       />
     </div>
   </div>

--- a/app/store/examine/conflicts.ts
+++ b/app/store/examine/conflicts.ts
@@ -5,7 +5,9 @@ import { highlightWord } from '~/util/html/highlight'
 
 export const useConflicts = defineStore('conflicts', () => {
   const exactMatches = ref<Array<ConflictListItem>>([])
+  const phoneticMatches = ref<Array<ConflictListItem>>([])
   const synonymMatches = ref<Array<ConflictListItem>>([])
+  const cobrsPhoneticMatches = ref<Array<ConflictListItem>>([])
 
   const loading = ref(false)
 
@@ -17,9 +19,7 @@ export const useConflicts = defineStore('conflicts', () => {
 
   /** The first `ConflictListItem`. */
   const firstConflictItem = computed(() =>
-    [...exactMatches.value, ...synonymMatches.value].at(
-      0
-    )
+    [...exactMatches.value, ...phoneticMatches.value, ...synonymMatches.value, ...cobrsPhoneticMatches.value].at(0)
   )
 
   function isConflictSelected(conflict: ConflictListItem) {
@@ -38,14 +38,17 @@ export const useConflicts = defineStore('conflicts', () => {
     }
   }
 
-  async function retrieveConflicts(query: string): Promise<[ConflictListItem[], ConflictListItem[], any[]]> {
+  async function retrieveConflicts(query: string): Promise<[ConflictListItem[], ConflictListItem[], ConflictListItem[], ConflictListItem[], any[]]> {
     const resp = await getConflicts(query)
     if (!resp.ok) throw new Error('Unable to retrieve exact matches')
     const json = await resp.json()
-    const exactMatches = parseExactMatches(json?.exactNames || [])
-    const similarMatches = parseSynonymMatches(json?.names || [])
+    const names: any[] = json?.names || []
+    const exact = parseExactMatches(json?.exactNames || [])
+    const phonetic = parseSynonymMatches(names.filter((r) => r.highlighting?.synonyms?.length > 0))
+    const synonym = parseSynonymMatches(names.filter((r) => r.highlighting?.stems?.length > 0))
+    const cobrs: ConflictListItem[] = []
     const histories = json?.histories
-    return [exactMatches, similarMatches, histories]
+    return [exact, phonetic, synonym, cobrs, histories]
   }
 
   function parseExactMatches(exactMatches: Array<any>): Array<ConflictListItem> {
@@ -128,9 +131,11 @@ export const useConflicts = defineStore('conflicts', () => {
     loading.value = true
     resetConflictLists()
     try {
-      const [exact, synonym, histories] = await retrieveConflicts(searchQuery)
+      const [exact, phonetic, synonym, cobrs, histories] = await retrieveConflicts(searchQuery)
       exactMatches.value = exact
+      phoneticMatches.value = phonetic
       synonymMatches.value = synonym
+      cobrsPhoneticMatches.value = cobrs
       return histories
     } catch (e) {
       resetMatches()
@@ -146,7 +151,9 @@ export const useConflicts = defineStore('conflicts', () => {
 
   function resetMatches() {
     exactMatches.value = []
+    phoneticMatches.value = []
     synonymMatches.value = []
+    cobrsPhoneticMatches.value = []
     loading.value = false
   }
 
@@ -204,7 +211,9 @@ export const useConflicts = defineStore('conflicts', () => {
   return {
     initialize,
     exactMatches,
+    phoneticMatches,
     synonymMatches,
+    cobrsPhoneticMatches,
     selectedConflicts,
     comparedConflicts,
     loading,


### PR DESCRIPTION
https://github.com/bcgov/entity/issues/32482

Summary
Splits the conflict search results into 4 distinct priority buckets 
as required by ticket #32482.

Changes
- `conflicts.ts` — splits the flat `synonymMatches` array into 3 separate refs based on the `highlighting` data already returned 
  by the `/possible-conflicts` API:
 - `phoneticMatches` → results with `highlighting.synonyms`
 - `synonymMatches`  → results with `highlighting.stems`
 - `cobrsPhoneticMatches` → empty (COBRS not in new API yet)

- `index.vue` — replaces the single "Possible Conflicts" bucket 
  with 4 labelled buckets in correct priority order

 Result
Conflict search now displays in correct order:
1. Exact Match
2. Phonetic Match (experimental)
3. Exact Word Order + Synonym Match
4. Character Swap Match

Notes
No changes to the API layer — `getConflicts` / `possible-conflicts`  endpoint unchanged
No changes to the highlighting logic — `highlightNameChoices` unchanged
Builds cleanly on top of `feature-solr-merged`
Previous attempt (PR #1597) was reverted because it only reordered  the array without fixing the underlying API — this PR targets the  correct base branch and uses the new API response shape