### PR TITLE
fix: align postConditions to /documents/restricted-words endpoint

### DIFF
--- a/app/util/namex-api.ts
+++ b/app/util/namex-api.ts
@@ -153,7 +153,15 @@ export async function postTrademarks(query: string) {
 }
 
 export async function postConditions(query: string) {
-  return postDocuments('restricted_words', query)
+  const url = getNamexApiUrl(`/documents/restricted-words`)
+  return callNamexApi(
+    url,
+    {
+      method: 'POST',
+      body: JSON.stringify({ type: 'plain_text', content: query }),
+    },
+    { 'content-type': 'application/json' }
+  )
 }
 
 export async function postHistories(query: string) {


### PR DESCRIPTION
Restore the restricted-words path alignment that was reverted, so the Recipe area's conditions call hits the backend route /documents/restricted-words instead of the legacy /documents:restricted_words (which 404s and breaks 'Failed to load Recipe area').
