### PR TITLE
chore: upgrade pnpm to latest-11 in CI workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,7 +24,7 @@ jobs:
     with:
       target: ${{ inputs.environment }}
       node_version: '24'
-      pnpm_version: '10.28.1'
+      pnpm_version: 'latest-11'
       app_name: 'name-examination-ui'
       working_directory: 'app'
     secrets:


### PR DESCRIPTION
Updates pnpm version references in GitHub Actions workflows from v10 to `latest-11`. Part of pnpm v11 upgrade (ticket #33875).

`package.json` `packageManager` field was updated in a separate PR.