### PR TITLE
#29880 fix: restore missing CSShighlight classes

### DIFF
--- a/app/components/examine/recipe/conflicts/ListItem.vue
+++ b/app/components/examine/recipe/conflicts/ListItem.vue
@@ -80,13 +80,18 @@ emitter.on('scrollToConflictObject', ({ obj, instant }) => {
 </script>
 
 <style>
-.stem-highlight {
-  color: #28a745;
+.exact-highlight {
+  color: #dc2626;
   font-weight: bold;
 }
 
-.synonym-stem-highlight {
+.synonym-highlight {
   color: #e0a800;
+  font-weight: bold;
+}
+
+.stem-highlight {
+  color: #28a745;
   font-weight: bold;
 }
 


### PR DESCRIPTION
https://github.com/bcgov/entity/issues/29880

- Add .exact-highlight (red #dc2626) for exact matches
- Rename .synonym-stem-highlight to .synonym-highlight (amber #e0a800)
- Restore .stem-highlight (green #28a745) for stem/phonetic matches

Ensures conflict highlighting works correctly with the new List.vue grouping architecture.