### PR TITLE
#29880 fix: restore conflict highlighting functionality

### DIFF
--- a/app/store/examine/conflicts.ts
+++ b/app/store/examine/conflicts.ts
@@ -1,5 +1,6 @@
 import type { ConflictList, ConflictListItem, ConflictSource } from '~/types'
 import { getPossibleConflicts } from '~/util/namex-api'
+import { highlightWord } from '~/util/html/highlight'
 import { useExaminationRecipe } from './recipe'
 
 export const useConflicts = defineStore('conflicts', () => {
@@ -59,15 +60,58 @@ export const useConflicts = defineStore('conflicts', () => {
       result.parent_type === 'CORP'
         ? ('CORP' as unknown as ConflictSource)
         : ('NAMEREQUEST' as unknown as ConflictSource)
+    const highlightedName = highlightNameChoices(result)
     return {
       text: result.name,
-      highlightedText: result.name,
+      highlightedText: highlightedName,
       nrNumber: result.parent_id,
       startDate: result.parent_start_date ?? '',
       jurisdiction: result.parent_jurisdiction ?? undefined,
       source,
       ui: { focused: false, open: false },
     }
+  }
+
+  /** Apply highlighting to conflict names based on API response data */
+  function highlightNameChoices(entry: any): string {
+    const name: string = entry?.name ?? ''
+    const highlighting = entry?.highlighting
+
+    // If we have nothing to highlight, keep original text intact
+    if (!name || !highlighting) {
+      return name
+    }
+
+    // Split into word and whitespace tokens so we preserve spacing exactly
+    const tokens = name.split(/(\s+)/)
+
+    const exactList: string[] = Array.isArray(highlighting.exact) ? highlighting.exact : []
+    const synonymList: string[] = Array.isArray(highlighting.synonyms) ? highlighting.synonyms : []
+    const stemList: string[] = Array.isArray(highlighting.stems) ? highlighting.stems : []
+
+    const applyFirstMatchingCategory = (word: string): string => {
+      // exact > synonym > stem (priority order)
+      for (const exact of exactList) {
+        const highlighted = highlightWord(exact, word, 'exact-highlight')
+        if (highlighted !== word) return highlighted
+      }
+
+      for (const synonym of synonymList) {
+        const highlighted = highlightWord(synonym, word, 'synonym-highlight')
+        if (highlighted !== word) return highlighted
+      }
+
+      for (const stem of stemList) {
+        const highlighted = highlightWord(stem, word, 'stem-highlight')
+        if (highlighted !== word) return highlighted
+      }
+
+      return word
+    }
+
+    return tokens
+      .map((token) => (token.trim().length === 0 ? token : applyFirstMatchingCategory(token)))
+      .join('')
   }
 
   /** Group a flat list of results into ConflictList buckets by a highlight key */


### PR DESCRIPTION
https://github.com/bcgov/entity/issues/29880

Summary
Restores the highlighting functionality that was removed in commit 395e0dc

- Add import of highlightWord utility from util/html/highlight
- Restore highlightNameChoices function to apply HTML highlighting
- Apply highlighting with priority: exact > synonym > stem
- Wraps matches in <span> tags with correct CSS classes

## Related Issues
- Commit 395e0dc removed all highlighting
- CSS classes were added in previous PR (fix/css-highlight-classes)
- This PR completes the highlighting restoration

