### PR TITLE
#33261 fix: remove result filtering to show all conflict matches

### DIFF
--- a/app/store/examine/conflicts.ts
+++ b/app/store/examine/conflicts.ts
@@ -114,7 +114,7 @@ export const useConflicts = defineStore('conflicts', () => {
       .join('')
   }
 
-  /** Group a flat list of results into ConflictList buckets by a highlight key */
+  /** Group all results into ConflictList buckets organized by category (stems/synonyms) */
   function groupIntoLists(
     results: any[],
     highlightKey: 'stems' | 'synonyms'
@@ -125,7 +125,6 @@ export const useConflicts = defineStore('conflicts', () => {
       highlightedText: highlightKey === 'stems' ? 'Stem Matches' : 'Synonym Matches',
       meta: undefined,
       children: results
-        .filter((r) => r.highlighting?.[highlightKey]?.length > 0)
         .map(mapToItem),
       ui: { focused: false, open: false },
     }


### PR DESCRIPTION
https://github.com/bcgov/entity/issues/33261


- Remove highlighting filter from groupIntoLists function
- Show ALL results from API (restores to ~700 items like namerequest)
- Keep bucketing/sorting logic by category (Phonetic, Synonym, Stem)
- Results now include items with empty highlighting arrays
- Maintains color highlighting where applicable
- Aligns with namerequest behavior of showing all Solr results


