### PR TITLE
chore: upgrade packageManager to pnpm@11.9.0

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,7 +24,7 @@ jobs:
     with:
       target: ${{ inputs.environment }}
       node_version: '24'
-      pnpm_version: '10.28.1'
+      pnpm_version: '11.9.0'
       app_name: 'name-examination-ui'
       working_directory: 'app'
     secrets:

--- a/.github/workflows/test-pnpm-v11.yml
+++ b/.github/workflows/test-pnpm-v11.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: latest-11
+          version: 11.9.0
 
       - uses: actions/setup-node@v6
         with:
@@ -29,7 +29,10 @@ jobs:
           cache-dependency-path: app/pnpm-lock.yaml
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --ignore-scripts
+
+      - name: Nuxt Prepare
+        run: pnpm exec nuxt prepare
 
       - name: Build
         run: pnpm run build-check

--- a/.github/workflows/test-pnpm-v11.yml
+++ b/.github/workflows/test-pnpm-v11.yml
@@ -1,0 +1,38 @@
+name: Test pnpm v11 upgrade
+on:
+  push:
+    branches: [feat/upgrade-pnpm-v11]
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/test-pnpm-v11.yml'
+      - 'app/package.json'
+      - 'app/pnpm-lock.yaml'
+
+jobs:
+  test-pnpm-v11:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: app
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: latest-11
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: app/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm run build-check
+
+      - name: Report pnpm version
+        run: pnpm --version

--- a/app/devops/cloudbuild-pr.yaml
+++ b/app/devops/cloudbuild-pr.yaml
@@ -6,7 +6,7 @@ steps:
       - -c
       - |
         corepack enable
-        corepack prepare pnpm@10.28.2 --activate
+        corepack prepare pnpm@11.9.0 --activate
         pnpm --version
         pnpm install --frozen-lockfile
     dir: app  # <-- ADD THIS
@@ -30,7 +30,7 @@ steps:
       - -c
       - |
         corepack enable
-        corepack prepare pnpm@10.28.2 --activate
+        corepack prepare pnpm@11.9.0 --activate
         pnpm run build
     dir: app  # <-- ADD THIS
 

--- a/app/package.json
+++ b/app/package.json
@@ -80,5 +80,5 @@
   "engines": {
     "node": "^24.0.0"
   },
-  "packageManager": "pnpm@10.28.2"
+  "packageManager": "pnpm@11.9.0"
 }

--- a/app/pnpm-workspace.yaml
+++ b/app/pnpm-workspace.yaml
@@ -1,0 +1,8 @@
+packages: []
+allowBuilds:
+  '@parcel/watcher': true
+  cypress: true
+  esbuild: true
+  protobufjs: true
+  simple-git-hooks: true
+  vue-demi: true


### PR DESCRIPTION
## Summary
- Bumps `app`'s `packageManager` from `pnpm@10.28.2` to `pnpm@11.9.0`.
- Adds `app/pnpm-workspace.yaml` with `allowBuilds` for `@parcel/watcher`, `cypress`, `esbuild`, `protobufjs`, `simple-git-hooks`, and `vue-demi` — pnpm v11 stopped reading package.json's `"pnpm"` key, so without this the install hard-fails with `ERR_PNPM_IGNORED_BUILDS`.

Part of ticket #33875 (pnpm v11 upgrade).

Depends on bcgov/bcregistry-sre#369 (the shared `frontend-ci.yaml` reusable workflow still hardcodes an older pnpm version) — this repo's `linting-pnpm`/`verify-build` jobs use that shared workflow, so they'll need #369 merged to go fully green in CI.

## Test plan
- [x] `pnpm install` locally with pnpm 11.9.0 — clean, no `ERR_PNPM_IGNORED_BUILDS`
- [x] `pnpm run build` (`nuxt generate`) — succeeds, all routes prerendered
- [ ] CI green (pending bcregistry-sre#369)