### PR TITLE
#33261 fix: add deduplication filter and remove duplicate bucket labels

### DIFF
--- a/app/store/examine/conflicts.ts
+++ b/app/store/examine/conflicts.ts
@@ -121,8 +121,8 @@ export const useConflicts = defineStore('conflicts', () => {
   ): Array<ConflictList> {
     if (!results?.length) return []
     const group: ConflictList = {
-      text: highlightKey === 'stems' ? 'Exact Word Order + Synonym Match' : 'Phonetic Match (experimental)',
-      highlightedText: highlightKey === 'stems' ? 'Exact Word Order + Synonym Match' : 'Phonetic Match (experimental)',
+      text: '',
+      highlightedText: '',
       meta: undefined,
       children: results
         .filter((r) => {


### PR DESCRIPTION
- Restore filter logic to deduplicate results by highlight type
- Remove duplicate labels from ConflictList (use template titles only)
- Results with synonyms → Phonetic Match bucket
- Results with stems-only → Exact Word Order + Synonym Match bucket
- Each result appears exactly once across all buckets


