### PR TITLE
#33261 fix: restore deduplication filter to groupIntoLists

### DIFF
--- a/app/store/examine/conflicts.ts
+++ b/app/store/examine/conflicts.ts
@@ -124,7 +124,18 @@ export const useConflicts = defineStore('conflicts', () => {
       text: '',
       highlightedText: '',
       meta: undefined,
-      children: results.map(mapToItem),
+      children: results
+        .filter((r) => {
+          const hasSynonyms = r.highlighting?.synonyms?.length > 0
+          const hasStems = r.highlighting?.stems?.length > 0
+
+          if (highlightKey === 'synonyms') {
+            return hasSynonyms
+          } else {
+            return hasStems && !hasSynonyms
+          }
+        })
+        .map(mapToItem),
       ui: { focused: false, open: false },
     }
     return group.children.length > 0 ? [group] : []


### PR DESCRIPTION
[#33261](https://github.com/bcgov/entity/issues/33261)

The merge from PR #1619 included the empty labels but accidentally omitted the filter logic. Restore the deduplication filter to properly separate results by highlight type:
- Results with synonyms → Phonetic Match bucket
- Results with stems-only → Exact Word Order + Synonym Match bucket
