### PR TITLE
#33261 fix: restore filter logic to include missing names

### DIFF
--- a/app/store/examine/conflicts.ts
+++ b/app/store/examine/conflicts.ts
@@ -128,11 +128,12 @@ export const useConflicts = defineStore('conflicts', () => {
         .filter((r) => {
           const hasSynonyms = r.highlighting?.synonyms?.length > 0
           const hasStems = r.highlighting?.stems?.length > 0
+          const hasExact = r.highlighting?.exact?.length > 0
 
           if (highlightKey === 'synonyms') {
             return hasSynonyms
           } else {
-            return hasStems && !hasSynonyms
+            return !hasSynonyms && (hasStems || hasExact)
           }
         })
         .map(mapToItem),


### PR DESCRIPTION
https://github.com/bcgov/entity/issues/33261

Include results that have exact highlighting but no synonyms or stems in the Exact Word Order + Synonym Match bucket. 

