### PR TITLE
#32842 Reorder conflict result buckets: move phonetic to bottom.

### DIFF
--- a/app/components/examine/recipe/conflicts/index.vue
+++ b/app/components/examine/recipe/conflicts/index.vue
@@ -20,11 +20,6 @@
       />
 
       <ExamineRecipeConflictsBucket
-        title="Phonetic Match (experimental)"
-        :conflict-lists="conflicts.phoneticMatches"
-      />
-
-      <ExamineRecipeConflictsBucket
         title="Exact Word Order + Synonym Match"
         :conflict-lists="conflicts.synonymMatches"
       />
@@ -32,6 +27,11 @@
       <ExamineRecipeConflictsBucket
         title="Character Swap Match"
         :conflict-lists="conflicts.cobrsPhoneticMatches"
+      />
+
+      <ExamineRecipeConflictsBucket
+        title="Phonetic Match (experimental)"
+        :conflict-lists="conflicts.phoneticMatches"
       />
 
     </div>

--- a/app/store/examine/conflicts.ts
+++ b/app/store/examine/conflicts.ts
@@ -20,9 +20,9 @@ export const useConflicts = defineStore('conflicts', () => {
   /** Flattened array of every `ConflictList` across all buckets. */
   const lists = computed<Array<ConflictList>>(() =>
     [
-      phoneticMatches.value,
       synonymMatches.value,
       cobrsPhoneticMatches.value,
+      phoneticMatches.value,
     ].flat()
   )
 


### PR DESCRIPTION
https://github.com/bcgov/entity/issues/32842
Conflict result buckets reordered: Exact Match → Exact Word Order + Synonym Match → Character Swap Match → Phonetic Match (experimental) (bottom)

 Move Phonetic Match (experimental) from position 2 to position 4 (last)

Files changed:
app/store/examine/conflicts.ts (1 change)
app/components/examine/recipe/conflicts/index.vue (1 change)

NB; Re-order back to original after phonetics is fixed.
